### PR TITLE
proof of concept for MapWithInput

### DIFF
--- a/Pidgin.Tests/ParseStateTests.cs
+++ b/Pidgin.Tests/ParseStateTests.cs
@@ -148,7 +148,7 @@ namespace Pidgin.Tests
         private static void Consume(string expected, ref ParseState<char> state)
         {
             var oldCol = state.ComputeSourcePos().Col;
-            AssertEqual(expected.AsSpan(), state.Peek(expected.Length));
+            AssertEqual(expected.AsSpan(), state.LookAhead(expected.Length));
             state.Advance(expected.Length);
             Assert.Equal(oldCol + expected.Length, state.ComputeSourcePos().Col);
         }

--- a/Pidgin.Tests/StringParserTests.cs
+++ b/Pidgin.Tests/StringParserTests.cs
@@ -2221,6 +2221,33 @@ namespace Pidgin.Tests
         }
 
         [Fact]
+        public void TestMapWithInput()
+        {
+            {
+                var parser = String("abc").Many().MapWithInput((input, result) => (input.ToString(), result.Count()));
+                AssertSuccess(parser.Parse("abc"), ("abc", 1), true);
+                AssertSuccess(parser.Parse("abcabc"), ("abcabc", 2), true);
+                AssertSuccess(  // long input, to check that it doesn't discard the buffer
+                    parser.Parse(string.Concat(Enumerable.Repeat("abc", 5000))),
+                    (string.Concat(Enumerable.Repeat("abc", 5000)), 5000),
+                    true
+                );
+
+                AssertFailure(
+                    parser.Parse("abd"),
+                    new ParseError<char>(
+                        Maybe.Just('d'),
+                        false,
+                        new[] { new Expected<char>(ImmutableArray.CreateRange("abc")) },
+                        new SourcePos(1,3),
+                        null
+                    ),
+                    true
+                );
+            }
+        }
+
+        [Fact]
         public void TestRec()
         {
             // roughly equivalent to String("foo").Separated(Char(' '))

--- a/Pidgin/ParseState.cs
+++ b/Pidgin/ParseState.cs
@@ -94,12 +94,16 @@ namespace Pidgin
             count -= bufferedCount;
         }
         // if it returns a span shorter than count it's because you reached the end of the input
-        public ReadOnlySpan<TToken> Peek(int count)
+        public ReadOnlySpan<TToken> LookAhead(int count)
         {
             Buffer(count);
-            return _buffer
-                .AsSpan()
-                .Slice(_currentIndex, Math.Min(_bufferedCount - _currentIndex, count));
+            return _buffer.AsSpan().Slice(_currentIndex, Math.Min(_bufferedCount - _currentIndex, count));
+        }
+        // if it returns a span shorter than count it's because you looked further back than the buffer goes
+        public ReadOnlySpan<TToken> LookBehind(int count)
+        {
+            var start = Math.Max(0, _currentIndex - count);
+            return _buffer.AsSpan().Slice(start, _currentIndex - start);
         }
 
         // postcondition: bufferedLength >= _currentIndex + min(readAhead, AmountLeft(_stream))

--- a/Pidgin/Parser.MapWithInput.cs
+++ b/Pidgin/Parser.MapWithInput.cs
@@ -1,0 +1,51 @@
+using System;
+
+namespace Pidgin
+{
+    public abstract partial class Parser<TToken, T>
+    {
+        public Parser<TToken, U> MapWithInput<U>(ReadOnlySpanFunc<TToken, T, U> selector)
+        {
+            if (selector == null)
+            {
+                throw new ArgumentNullException(nameof(selector));
+            }
+            return new MapWithInputParser<U>(this, selector);
+        }
+
+        private class MapWithInputParser<U> : Parser<TToken, U>
+        {
+            private Parser<TToken, T> _parser;
+            private ReadOnlySpanFunc<TToken, T, U> _selector;
+
+            public MapWithInputParser(Parser<TToken, T> parser, ReadOnlySpanFunc<TToken, T, U> selector)
+            {
+                _parser = parser;
+                _selector = selector;
+            }
+
+            internal override InternalResult<U> Parse(ref ParseState<TToken> state)
+            {
+                var start = state.Location;
+
+                state.PushBookmark();  // don't discard input buffer
+                var result = _parser.Parse(ref state);
+
+
+                if (!result.Success)
+                {
+                    state.PopBookmark();
+                    return InternalResult.Failure<U>(result.ConsumedInput);
+                }
+
+
+                var delta = state.Location - start;
+                var val = _selector(state.LookBehind(delta), result.Value);
+
+                state.PopBookmark();
+
+                return InternalResult.Success<U>(val, result.ConsumedInput);
+            }
+        }
+    }
+}

--- a/Pidgin/Parser.MapWithInput.cs
+++ b/Pidgin/Parser.MapWithInput.cs
@@ -4,6 +4,18 @@ namespace Pidgin
 {
     public abstract partial class Parser<TToken, T>
     {
+        /// <summary>
+        /// Returns a parser which runs the current parser and applies a selector function.
+        /// The selector function receives a <see cref="ReadOnlySpan{TToken}"/> as its first argument, and the result of the current parser as its second argument.
+        /// The <see cref="ReadOnlySpan{TToken}"/> represents the sequence of input tokens which were consumed by the parser.
+        /// </summary>
+        /// <param name="selector">
+        /// A selector function which computes a result of type <typeparamref name="U"/>.
+        /// The arguments of the selector function are a <see cref="ReadOnlySpan{TToken}"/> containing the sequence of input tokens which were consumed by this parser,
+        /// and the result of this parser.
+        /// </param>
+        /// <typeparam name="U">The result type</typeparam>
+        /// <returns>A parser which runs the current parser and applies a selector function.</returns>
         public Parser<TToken, U> MapWithInput<U>(ReadOnlySpanFunc<TToken, T, U> selector)
         {
             if (selector == null)

--- a/Pidgin/Parser.MapWithInput.cs
+++ b/Pidgin/Parser.MapWithInput.cs
@@ -1,4 +1,5 @@
 using System;
+using System.ComponentModel;
 
 namespace Pidgin
 {
@@ -8,6 +9,8 @@ namespace Pidgin
         /// Returns a parser which runs the current parser and applies a selector function.
         /// The selector function receives a <see cref="ReadOnlySpan{TToken}"/> as its first argument, and the result of the current parser as its second argument.
         /// The <see cref="ReadOnlySpan{TToken}"/> represents the sequence of input tokens which were consumed by the parser.
+        /// 
+        /// This allows you to write "pattern"-style parsers which match a sequence of tokens and return a view of the part of the input stream which they matched.
         /// </summary>
         /// <param name="selector">
         /// A selector function which computes a result of type <typeparamref name="U"/>.

--- a/Pidgin/Parser.Sequence.cs
+++ b/Pidgin/Parser.Sequence.cs
@@ -24,7 +24,7 @@ namespace Pidgin
 
             internal sealed override InternalResult<TEnumerable> Parse(ref ParseState<TToken> state)
             {
-                var span = state.Peek(_valueTokens.Length);  // span.Length <= _valueTokens.Length
+                var span = state.LookAhead(_valueTokens.Length);  // span.Length <= _valueTokens.Length
                 
                 var errorPos = -1;
                 for (var i = 0; i < span.Length; i++)
@@ -84,7 +84,7 @@ namespace Pidgin
 
             internal sealed override InternalResult<TEnumerable> Parse(ref ParseState<TToken> state)
             {
-                var span = state.Peek(_valueTokens.Length);  // span.Length <= _valueTokens.Length
+                var span = state.LookAhead(_valueTokens.Length);  // span.Length <= _valueTokens.Length
                 
                 var errorPos = -1;
                 for (var i = 0; i < span.Length; i++)

--- a/Pidgin/Parser.String.cs
+++ b/Pidgin/Parser.String.cs
@@ -59,7 +59,7 @@ namespace Pidgin
 
             internal sealed override InternalResult<string> Parse(ref ParseState<char> state)
             {
-                var span = state.Peek(_value.Length);  // span.Length <= _valueTokens.Length
+                var span = state.LookAhead(_value.Length);  // span.Length <= _valueTokens.Length
 
                 var errorPos = -1;
                 for (var i = 0; i < span.Length; i++)

--- a/Pidgin/ReadOnlySpanFunc.cs
+++ b/Pidgin/ReadOnlySpanFunc.cs
@@ -2,5 +2,14 @@ using System;
 
 namespace Pidgin
 {
-    public delegate TReturn ReadOnlySpanFunc<TToken, in TParam, out TReturn>(ReadOnlySpan<TToken> span, TParam param);
+    /// <summary>
+    /// A function which computes a result from a <see cref="ReadOnlySpan{TToken}"/> and an additional argument.
+    /// </summary>
+    /// <param name="span">The input span</param>
+    /// <param name="param">An additional argument</param>
+    /// <typeparam name="T">The type of elements of the span</typeparam>
+    /// <typeparam name="TParam">The type of the additional argument</typeparam>
+    /// <typeparam name="TReturn">The type of the result computed by the function</typeparam>
+    /// <returns>The result</returns>
+    public delegate TReturn ReadOnlySpanFunc<T, in TParam, out TReturn>(ReadOnlySpan<T> span, TParam param);
 }

--- a/Pidgin/ReadOnlySpanFunc.cs
+++ b/Pidgin/ReadOnlySpanFunc.cs
@@ -1,0 +1,6 @@
+using System;
+
+namespace Pidgin
+{
+    public delegate TReturn ReadOnlySpanFunc<TToken, in TParam, out TReturn>(ReadOnlySpan<TToken> span, TParam param);
+}


### PR DESCRIPTION
Closes #40.

```csharp
namespace Pidgin
{
    public delegate TReturn ReadOnlySpanFunc<TToken, in TParam, out TReturn>(ReadOnlySpan<TToken> span, TParam param);

    public abstract class Parser<TToken, T>
    {
        public Parser<TToken, U> MapWithInput<U>(ReadOnlySpanFunc<TToken, T, U> selector);
    }
}
```

I'm punting on the question of running a parser without computing intermediate results. `MapWithInput` runs its argument parser normally and computes its result. The result is passed to `selector`, along with a `ReadOnlySpan` of the extent of the input which was matched by the parser.

I think this is less surprising than either _not_ having access to the result, or non-locally turning off computing intermediate results altogether.