### PR TITLE
Public API for custom parsers, and new MapWithInputRange parser

### DIFF
--- a/Pidgin.CodeGen/MapGenerator.cs
+++ b/Pidgin.CodeGen/MapGenerator.cs
@@ -118,7 +118,7 @@ namespace Pidgin
             {string.Join($"{Environment.NewLine}            ", parserFieldAssignments)}
         }}
 
-        internal sealed override InternalResult<R> Parse(ref ParseState<TToken> state)
+        public sealed override InternalResult<R> Parse(ref ParseState<TToken> state)
         {{
             var consumedInput = false;
 
@@ -148,7 +148,7 @@ namespace Pidgin
             {{
                 return InternalResult.Failure<R>(consumedInput);
             }}";
-        
+
         private static string EnglishNumber(int num)
         {
             switch (num)

--- a/Pidgin.Tests/ArgumentNullTests.cs
+++ b/Pidgin.Tests/ArgumentNullTests.cs
@@ -103,15 +103,15 @@ namespace Pidgin.Tests
                         ).Select(xs => xs.ToArray())
                     )
             );
-        
+
         private static Maybe<IEnumerable<T>> Sequence<T>(IEnumerable<Maybe<T>> maybes)
             => maybes.All(x => x.HasValue)
                 ? Maybe.Just(maybes.Select(x => x.Value))
                 : Maybe.Nothing<IEnumerable<T>>();
-        
+
         private static IEnumerable<T> Cat<T>(IEnumerable<Maybe<T>> maybes)
             => maybes.Where(x => x.HasValue).Select(x => x.Value);
-        
+
         private static Maybe<object?> GetArg(Type parameterType, bool shouldBeNull)
         {
             if (shouldBeNull)
@@ -177,7 +177,7 @@ namespace Pidgin.Tests
         {
             public AParser() { }
 
-            internal override InternalResult<T> Parse(ref ParseState<TToken> state)
+            public override InternalResult<T> Parse(ref ParseState<TToken> state)
             {
                 throw new NotImplementedException();
             }

--- a/Pidgin/InternalResult.cs
+++ b/Pidgin/InternalResult.cs
@@ -1,17 +1,18 @@
 namespace Pidgin
 {
-    internal static class InternalResult
+    public static class InternalResult
     {
         public static InternalResult<T> Success<T>(T value, bool consumedInput)
             => new InternalResult<T>(true, consumedInput, value);
-        
+
         /// <summary>
         /// NB! Remember to set IParseState.Error when you return a failure result
         /// </summary>
         public static InternalResult<T> Failure<T>(bool consumedInput)
             => new InternalResult<T>(false, consumedInput, default(T)!);
     }
-    internal readonly struct InternalResult<T>
+
+    public readonly struct InternalResult<T>
     {
         public bool Success { get; }
         public bool ConsumedInput { get; }

--- a/Pidgin/ParseState.Error.cs
+++ b/Pidgin/ParseState.Error.cs
@@ -6,13 +6,13 @@ using System.Linq;
 
 namespace Pidgin
 {
-    internal partial struct ParseState<TToken>
+    public partial struct ParseState<TToken>
     {
         private bool _eof;
         private Maybe<TToken> _unexpected;
         private int _errorLocation;
         private string? _message;
-        public InternalError<TToken> Error
+        internal InternalError<TToken> Error
         {
             get
             {
@@ -63,7 +63,7 @@ namespace Pidgin
         // of the _expecteds taller than that height. Note that expecteds that were
         // committed may still be rolled back, if we're running in a nested transaction.
         // (When read bottom to top, _expectedBookmarks is monotonically increasing.)
-        // 
+        //
         // That's why I can't just use ImmutableSortedSet.Builder here:
         // I need to retain the order in which expecteds were added, so that I can drop them if necessary.
         //

--- a/Pidgin/ParseState.cs
+++ b/Pidgin/ParseState.cs
@@ -10,7 +10,7 @@ namespace Pidgin
     /// A mutable struct! Careful!
     /// </summary>
     [StructLayout(LayoutKind.Auto)]
-    internal ref partial struct ParseState<TToken>
+    public ref partial struct ParseState<TToken>
     {
         private static readonly bool _needsClear =
 #if NETCOREAPP
@@ -119,13 +119,13 @@ namespace Pidgin
                 _currentIndex = Math.Min(_currentIndex + count, _span.Length);
                 return;
             }
-            
+
             var alreadyBufferedCount = Math.Min(count, _bufferedCount - _currentIndex);
             _currentIndex += alreadyBufferedCount;
             count -= alreadyBufferedCount;
 
             Buffer(count);
-            
+
             var bufferedCount = Math.Min(count, _bufferedCount - _currentIndex);
             _currentIndex += bufferedCount;
             count -= bufferedCount;
@@ -203,7 +203,7 @@ namespace Pidgin
                 _bufferedCount += _stream!.ReadInto(_buffer, _bufferedCount, amountToRead);
             }
         }
-        
+
         public void PushBookmark()
         {
             _bookmarks.Add(Location);
@@ -217,7 +217,7 @@ namespace Pidgin
         public void Rewind()
         {
             var bookmark = _bookmarks.Pop();
-            
+
             var delta = Location - bookmark;
 
             if (delta > _currentIndex)

--- a/Pidgin/Parser.Assert.cs
+++ b/Pidgin/Parser.Assert.cs
@@ -73,10 +73,10 @@ namespace Pidgin
             _message = message;
         }
 
-        internal sealed override InternalResult<T> Parse(ref ParseState<TToken> state)
+        public sealed override InternalResult<T> Parse(ref ParseState<TToken> state)
         {
             state.BeginExpectedTran();
-            var result = _parser.Parse(ref state);                
+            var result = _parser.Parse(ref state);
             state.EndExpectedTran(!result.Success);
             if (!result.Success)
             {

--- a/Pidgin/Parser.Bind.cs
+++ b/Pidgin/Parser.Bind.cs
@@ -57,7 +57,7 @@ namespace Pidgin
             _result = result;
         }
 
-        internal sealed override InternalResult<R> Parse(ref ParseState<TToken> state)
+        public sealed override InternalResult<R> Parse(ref ParseState<TToken> state)
         {
             var result = _parser.Parse(ref state);
             if (!result.Success)

--- a/Pidgin/Parser.Chain.cs
+++ b/Pidgin/Parser.Chain.cs
@@ -26,7 +26,7 @@ namespace Pidgin
             _factory = factory;
         }
 
-        internal override InternalResult<U> Parse(ref ParseState<TToken> state)
+        public override InternalResult<U> Parse(ref ParseState<TToken> state)
         {
             var result1 = _parser.Parse(ref state);
             if (!result1.Success)

--- a/Pidgin/Parser.CurrentPos.cs
+++ b/Pidgin/Parser.CurrentPos.cs
@@ -12,7 +12,7 @@ namespace Pidgin
 
     internal sealed class CurrentPosParser<TToken> : Parser<TToken, SourcePos>
     {
-        internal override InternalResult<SourcePos> Parse(ref ParseState<TToken> state)
+        public override InternalResult<SourcePos> Parse(ref ParseState<TToken> state)
             => InternalResult.Success(state.ComputeSourcePos(), false);
     }
 }

--- a/Pidgin/Parser.End.cs
+++ b/Pidgin/Parser.End.cs
@@ -11,7 +11,7 @@ namespace Pidgin
 
     internal sealed class EndParser<TToken> : Parser<TToken, Unit>
     {
-        internal sealed override InternalResult<Unit> Parse(ref ParseState<TToken> state)
+        public sealed override InternalResult<Unit> Parse(ref ParseState<TToken> state)
         {
             if (state.HasCurrent)
             {

--- a/Pidgin/Parser.Fail.cs
+++ b/Pidgin/Parser.Fail.cs
@@ -20,7 +20,7 @@ namespace Pidgin
             return new FailParser<TToken, T>(message);
         }
     }
-        
+
     internal sealed class FailParser<TToken, T> : Parser<TToken, T>
     {
         private static readonly Expected<TToken> _expected
@@ -32,7 +32,7 @@ namespace Pidgin
             _message = message;
         }
 
-        internal sealed override InternalResult<T> Parse(ref ParseState<TToken> state)
+        public sealed override InternalResult<T> Parse(ref ParseState<TToken> state)
         {
             state.Error = new InternalError<TToken>(
                 Maybe.Nothing<TToken>(),

--- a/Pidgin/Parser.Labelled.cs
+++ b/Pidgin/Parser.Labelled.cs
@@ -21,7 +21,7 @@ namespace Pidgin
             }
             return WithExpected(ImmutableArray.Create(new Expected<TToken>(label)));
         }
-            
+
         internal Parser<TToken, T> WithExpected(ImmutableArray<Expected<TToken>> expected)
             => new WithExpectedParser<TToken, T>(this, expected);
     }
@@ -37,7 +37,7 @@ namespace Pidgin
             _expected = expected;
         }
 
-        internal override InternalResult<T> Parse(ref ParseState<TToken> state)
+        public override InternalResult<T> Parse(ref ParseState<TToken> state)
         {
             state.BeginExpectedTran();
             var result = _parser.Parse(ref state);

--- a/Pidgin/Parser.Lookahead.cs
+++ b/Pidgin/Parser.Lookahead.cs
@@ -30,7 +30,7 @@ namespace Pidgin
             _parser = parser;
         }
 
-        internal override InternalResult<T> Parse(ref ParseState<TToken> state)
+        public override InternalResult<T> Parse(ref ParseState<TToken> state)
         {
             state.PushBookmark();
 

--- a/Pidgin/Parser.Map.Generated.cs
+++ b/Pidgin/Parser.Map.Generated.cs
@@ -416,7 +416,7 @@ namespace Pidgin
     {
         internal new abstract MapParserBase<TToken, U> Map<U>(Func<T, U> func);
     }
-    
+
     internal sealed class Map1Parser<TToken, T1, R> : MapParserBase<TToken, R>
     {
         private readonly Func<T1, R> _func;
@@ -431,11 +431,11 @@ namespace Pidgin
             _p1 = parser1;
         }
 
-        internal sealed override InternalResult<R> Parse(ref ParseState<TToken> state)
+        public sealed override InternalResult<R> Parse(ref ParseState<TToken> state)
         {
             var consumedInput = false;
 
-            
+
             var result1 = _p1.Parse(ref state);
             consumedInput = consumedInput || result1.ConsumedInput;
             if (!result1.Success)
@@ -475,11 +475,11 @@ namespace Pidgin
             _p2 = parser2;
         }
 
-        internal sealed override InternalResult<R> Parse(ref ParseState<TToken> state)
+        public sealed override InternalResult<R> Parse(ref ParseState<TToken> state)
         {
             var consumedInput = false;
 
-            
+
             var result1 = _p1.Parse(ref state);
             consumedInput = consumedInput || result1.ConsumedInput;
             if (!result1.Success)
@@ -531,11 +531,11 @@ namespace Pidgin
             _p3 = parser3;
         }
 
-        internal sealed override InternalResult<R> Parse(ref ParseState<TToken> state)
+        public sealed override InternalResult<R> Parse(ref ParseState<TToken> state)
         {
             var consumedInput = false;
 
-            
+
             var result1 = _p1.Parse(ref state);
             consumedInput = consumedInput || result1.ConsumedInput;
             if (!result1.Success)
@@ -599,11 +599,11 @@ namespace Pidgin
             _p4 = parser4;
         }
 
-        internal sealed override InternalResult<R> Parse(ref ParseState<TToken> state)
+        public sealed override InternalResult<R> Parse(ref ParseState<TToken> state)
         {
             var consumedInput = false;
 
-            
+
             var result1 = _p1.Parse(ref state);
             consumedInput = consumedInput || result1.ConsumedInput;
             if (!result1.Success)
@@ -679,11 +679,11 @@ namespace Pidgin
             _p5 = parser5;
         }
 
-        internal sealed override InternalResult<R> Parse(ref ParseState<TToken> state)
+        public sealed override InternalResult<R> Parse(ref ParseState<TToken> state)
         {
             var consumedInput = false;
 
-            
+
             var result1 = _p1.Parse(ref state);
             consumedInput = consumedInput || result1.ConsumedInput;
             if (!result1.Success)
@@ -771,11 +771,11 @@ namespace Pidgin
             _p6 = parser6;
         }
 
-        internal sealed override InternalResult<R> Parse(ref ParseState<TToken> state)
+        public sealed override InternalResult<R> Parse(ref ParseState<TToken> state)
         {
             var consumedInput = false;
 
-            
+
             var result1 = _p1.Parse(ref state);
             consumedInput = consumedInput || result1.ConsumedInput;
             if (!result1.Success)
@@ -875,11 +875,11 @@ namespace Pidgin
             _p7 = parser7;
         }
 
-        internal sealed override InternalResult<R> Parse(ref ParseState<TToken> state)
+        public sealed override InternalResult<R> Parse(ref ParseState<TToken> state)
         {
             var consumedInput = false;
 
-            
+
             var result1 = _p1.Parse(ref state);
             consumedInput = consumedInput || result1.ConsumedInput;
             if (!result1.Success)
@@ -991,11 +991,11 @@ namespace Pidgin
             _p8 = parser8;
         }
 
-        internal sealed override InternalResult<R> Parse(ref ParseState<TToken> state)
+        public sealed override InternalResult<R> Parse(ref ParseState<TToken> state)
         {
             var consumedInput = false;
 
-            
+
             var result1 = _p1.Parse(ref state);
             consumedInput = consumedInput || result1.ConsumedInput;
             if (!result1.Success)

--- a/Pidgin/Parser.MapWithInput.cs
+++ b/Pidgin/Parser.MapWithInput.cs
@@ -9,7 +9,7 @@ namespace Pidgin
         /// Returns a parser which runs the current parser and applies a selector function.
         /// The selector function receives a <see cref="ReadOnlySpan{TToken}"/> as its first argument, and the result of the current parser as its second argument.
         /// The <see cref="ReadOnlySpan{TToken}"/> represents the sequence of input tokens which were consumed by the parser.
-        /// 
+        ///
         /// This allows you to write "pattern"-style parsers which match a sequence of tokens and return a view of the part of the input stream which they matched.
         /// </summary>
         /// <param name="selector">
@@ -40,7 +40,7 @@ namespace Pidgin
             _selector = selector;
         }
 
-        internal override InternalResult<U> Parse(ref ParseState<TToken> state)
+        public override InternalResult<U> Parse(ref ParseState<TToken> state)
         {
             var start = state.Location;
 

--- a/Pidgin/Parser.MapWithInputRange.cs
+++ b/Pidgin/Parser.MapWithInputRange.cs
@@ -1,0 +1,113 @@
+using System;
+using System.ComponentModel;
+
+namespace Pidgin
+{
+    #if NETSTANDARD2_0 || NETFRAMEWORK451
+    public struct Range : IEquatable<Range>
+    {
+        public int Start { get; }
+        public int End { get; }
+
+        public Range(int start, int end) {
+            Start = start;
+            End = end;
+        }
+
+        public bool Equals(Range other) =>
+            Start == other.Start && End == other.End;
+    }
+    #else
+    using Range = System.Range;
+    #endif
+
+    public readonly ref struct InputRange<T>
+    {
+        public readonly ReadOnlySpan<T> Span;
+        public readonly Range Range;
+
+        public InputRange(ReadOnlySpan<T> span, Range range)
+        {
+            Span = span;
+            Range = range;
+        }
+
+        public override string ToString() => $"[{Range}] {Span.ToString()}";
+    }
+
+    /// <summary>
+    /// A function which computes a result from a <see cref="InputRange{TToken}"/> and an additional argument.
+    /// </summary>
+    /// <param name="span">The input span</param>
+    /// <param name="param">An additional argument</param>
+    /// <typeparam name="T">The type of elements of the span</typeparam>
+    /// <typeparam name="TParam">The type of the additional argument</typeparam>
+    /// <typeparam name="TReturn">The type of the result computed by the function</typeparam>
+    /// <returns>The result</returns>
+    public delegate TReturn InputRangeFunc<T, in TParam, out TReturn>(InputRange<T> span, TParam param);
+
+    public abstract partial class Parser<TToken, T>
+    {
+        /// <summary>
+        /// Returns a parser which runs the current parser and applies a selector function.
+        /// The selector function receives a <see cref="InputRange{TToken}"/> as its first argument, and the result of the current parser as its second argument.
+        /// The <see cref="InputRange{TToken}"/> represents the sequence of input tokens which were consumed by the parser.
+        ///
+        /// This allows you to write "pattern"-style parsers which match a sequence of tokens and return a view of the part of the input stream which they matched.
+        /// </summary>
+        /// <param name="selector">
+        /// A selector function which computes a result of type <typeparamref name="U"/>.
+        /// The arguments of the selector function are a <see cref="InputRange{TToken}"/> containing the sequence of input tokens which were consumed by this parser,
+        /// and the result of this parser.
+        /// </param>
+        /// <typeparam name="U">The result type</typeparam>
+        /// <returns>A parser which runs the current parser and applies a selector function.</returns>
+        public Parser<TToken, U> MapWithInputRange<U>(InputRangeFunc<TToken, T, U> selector)
+        {
+            if (selector == null)
+            {
+                throw new ArgumentNullException(nameof(selector));
+            }
+            return new MapWithInputRangeParser<TToken, T, U>(this, selector);
+        }
+    }
+
+
+
+    internal class MapWithInputRangeParser<TToken, T, U> : Parser<TToken, U>
+    {
+        private Parser<TToken, T> _parser;
+        private InputRangeFunc<TToken, T, U> _selector;
+
+        public MapWithInputRangeParser(Parser<TToken, T> parser, InputRangeFunc<TToken, T, U> selector)
+        {
+            _parser = parser;
+            _selector = selector;
+        }
+
+        public override InternalResult<U> Parse(ref ParseState<TToken> state)
+        {
+            var start = state.Location;
+
+            state.PushBookmark();    // don't discard input buffer
+            var result = _parser.Parse(ref state);
+
+
+            if (!result.Success)
+            {
+                state.PopBookmark();
+                return InternalResult.Failure<U>(result.ConsumedInput);
+            }
+
+
+            var delta = state.Location - start;
+            var inputRange = new InputRange<TToken>(state.LookBehind(delta), new Range(start, state.Location));
+            var val = _selector(inputRange, result.Value);
+
+            state.PopBookmark();
+
+            return InternalResult.Success<U>(val, result.ConsumedInput);
+        }
+    }
+
+}

--- a/Pidgin/Parser.Not.cs
+++ b/Pidgin/Parser.Not.cs
@@ -20,10 +20,10 @@ namespace Pidgin
             {
                 throw new ArgumentNullException(nameof(parser));
             }
-            return new NegatedParser<TToken, T>(parser);            
+            return new NegatedParser<TToken, T>(parser);
         }
     }
-        
+
     internal sealed class NegatedParser<TToken, T> : Parser<TToken, Unit>
     {
         private readonly Parser<TToken, T> _parser;
@@ -33,7 +33,7 @@ namespace Pidgin
             _parser = parser;
         }
 
-        internal sealed override InternalResult<Unit> Parse(ref ParseState<TToken> state)
+        public sealed override InternalResult<Unit> Parse(ref ParseState<TToken> state)
         {
             var startingLocation = state.Location;
             var token = state.HasCurrent ? Maybe.Just(state.Current) : Maybe.Nothing<TToken>();

--- a/Pidgin/Parser.OneOf.cs
+++ b/Pidgin/Parser.OneOf.cs
@@ -124,7 +124,7 @@ namespace Pidgin
         }
 
         // see comment about expecteds in ParseState.Error.cs
-        internal sealed override InternalResult<T> Parse(ref ParseState<TToken> state)
+        public sealed override InternalResult<T> Parse(ref ParseState<TToken> state)
         {
             var firstTime = true;
             var err = new InternalError<TToken>(
@@ -181,7 +181,7 @@ namespace Pidgin
             var list = parsers is ICollection<Parser<TToken, T>> coll
                 ? new List<Parser<TToken, T>>(coll.Count)
                 : new List<Parser<TToken, T>>();
-            
+
             foreach (var p in parsers)
             {
                 if (p == null)

--- a/Pidgin/Parser.Rec.cs
+++ b/Pidgin/Parser.Rec.cs
@@ -49,7 +49,7 @@ namespace Pidgin
             return new RecParser<TToken, T>(parser);
         }
     }
-        
+
     internal sealed class RecParser<TToken, T> : Parser<TToken, T>
     {
         private readonly Lazy<Parser<TToken, T>> _lazy;
@@ -59,7 +59,7 @@ namespace Pidgin
             _lazy = lazy;
         }
 
-        internal sealed override InternalResult<T> Parse(ref ParseState<TToken> state)
+        public sealed override InternalResult<T> Parse(ref ParseState<TToken> state)
             => _lazy.Value.Parse(ref state);
     }
 }

--- a/Pidgin/Parser.RecoverWith.cs
+++ b/Pidgin/Parser.RecoverWith.cs
@@ -31,7 +31,7 @@ namespace Pidgin
         }
 
         // see comment about expecteds in ParseState.Error.cs
-        internal override InternalResult<T> Parse(ref ParseState<TToken> state)
+        public override InternalResult<T> Parse(ref ParseState<TToken> state)
         {
             state.BeginExpectedTran();
             var result = _parser.Parse(ref state);
@@ -44,7 +44,7 @@ namespace Pidgin
             state.EndExpectedTran(false);
 
             var recoverParser = _errorHandler(state.BuildError(parserExpecteds.AsEnumerable()));
-            
+
             parserExpecteds.Dispose(clearArray: true);
 
             return recoverParser.Parse(ref state);

--- a/Pidgin/Parser.Repeat.cs
+++ b/Pidgin/Parser.Repeat.cs
@@ -9,7 +9,7 @@ namespace Pidgin
         /// <summary>
         /// Creates a parser which applies <paramref name="parser"/> <paramref name="count"/> times,
         /// packing the resulting <c>char</c>s into a <c>string</c>.
-        /// 
+        ///
         /// <para>
         /// Equivalent to <c>parser.Repeat(count).Select(string.Concat)</c>.
         /// </para>
@@ -65,7 +65,7 @@ namespace Pidgin
             _count = count;
         }
 
-        internal override InternalResult<string> Parse(ref ParseState<TToken> state)
+        public override InternalResult<string> Parse(ref ParseState<TToken> state)
         {
             var consumedInput = false;
             var builder = new InplaceStringBuilder(_count);

--- a/Pidgin/Parser.Return.cs
+++ b/Pidgin/Parser.Return.cs
@@ -21,7 +21,7 @@ namespace Pidgin
             _value = value;
         }
 
-        internal sealed override InternalResult<T> Parse(ref ParseState<TToken> state)
+        public sealed override InternalResult<T> Parse(ref ParseState<TToken> state)
             => InternalResult.Success<T>(_value, false);
     }
 }

--- a/Pidgin/Parser.Separated.cs
+++ b/Pidgin/Parser.Separated.cs
@@ -21,7 +21,7 @@ namespace Pidgin
             return this.SeparatedAtLeastOnce(separator)
                 .Or(ReturnEmptyEnumerable);
         }
-        
+
         /// <summary>
         /// Creates a parser which applies the current parser at least once, interleaved with a specified parser.
         /// The resulting parser ignores the return value of the separator parser.
@@ -53,7 +53,7 @@ namespace Pidgin
             }
             return this.Before(separator).Many();
         }
-        
+
         /// <summary>
         /// Creates a parser which applies the current parser at least once, interleaved and terminated with a specified parser.
         /// The resulting parser ignores the return value of the separator parser.
@@ -86,7 +86,7 @@ namespace Pidgin
             return this.SeparatedAndOptionallyTerminatedAtLeastOnce(separator)
                 .Or(ReturnEmptyEnumerable);
         }
-        
+
         /// <summary>
         /// Creates a parser which applies the current parser at least once, interleaved and optionally terminated with a specified parser.
         /// The resulting parser ignores the return value of the separator parser.
@@ -115,7 +115,7 @@ namespace Pidgin
             _remainderParser = separator.Then(parser);
         }
 
-        internal override InternalResult<IEnumerable<T>> Parse(ref ParseState<TToken> state)
+        public override InternalResult<IEnumerable<T>> Parse(ref ParseState<TToken> state)
         {
             var result = _parser.Parse(ref state);
             if (!result.Success)
@@ -163,7 +163,7 @@ namespace Pidgin
             _separator = separator;
         }
 
-        internal override InternalResult<IEnumerable<T>> Parse(ref ParseState<TToken> state)
+        public override InternalResult<IEnumerable<T>> Parse(ref ParseState<TToken> state)
         {
             var result = _parser.Parse(ref state);
             if (!result.Success)

--- a/Pidgin/Parser.Sequence.cs
+++ b/Pidgin/Parser.Sequence.cs
@@ -82,23 +82,23 @@ namespace Pidgin
             _parsers = parsers;
         }
 
-        internal sealed override InternalResult<IEnumerable<T>> Parse(ref ParseState<TToken> state)
+        public sealed override InternalResult<IEnumerable<T>> Parse(ref ParseState<TToken> state)
         {
             var consumedInput = false;
             var ts = new T[_parsers.Length];
-            
+
             for (var i = 0; i < _parsers.Length; i++)
             {
                 var p = _parsers[i];
-            
+
                 var result = p.Parse(ref state);
                 consumedInput = consumedInput || result.ConsumedInput;
-            
+
                 if (!result.Success)
                 {
                     return InternalResult.Failure<IEnumerable<T>>(consumedInput);
                 }
-            
+
                 ts[i] = result.Value;
             }
 
@@ -151,10 +151,10 @@ namespace Pidgin
             _valueTokens = value.ToImmutableArray();
         }
 
-        internal sealed override InternalResult<TEnumerable> Parse(ref ParseState<TToken> state)
+        public sealed override InternalResult<TEnumerable> Parse(ref ParseState<TToken> state)
         {
             var span = state.LookAhead(_valueTokens.Length);  // span.Length <= _valueTokens.Length
-            
+
             var errorPos = -1;
             for (var i = 0; i < span.Length; i++)
             {
@@ -211,10 +211,10 @@ namespace Pidgin
             _valueTokens = value.ToImmutableArray();
         }
 
-        internal sealed override InternalResult<TEnumerable> Parse(ref ParseState<TToken> state)
+        public sealed override InternalResult<TEnumerable> Parse(ref ParseState<TToken> state)
         {
             var span = state.LookAhead(_valueTokens.Length);  // span.Length <= _valueTokens.Length
-            
+
             var errorPos = -1;
             for (var i = 0; i < span.Length; i++)
             {

--- a/Pidgin/Parser.String.cs
+++ b/Pidgin/Parser.String.cs
@@ -10,7 +10,7 @@ namespace Pidgin
         /// </summary>
         /// <param name="str">The string to parse</param>
         /// <returns>A parser that parses and returns a literal string</returns>
-        /// 
+        ///
         public static Parser<char, string> String(string str)
         {
             if (str == null)
@@ -19,7 +19,7 @@ namespace Pidgin
             }
             return Parser<char>.Sequence<string>(str);
         }
-        
+
         /// <summary>
         /// Creates a parser that parses and returns a literal string, in a case insensitive manner.
         /// The parser returns the actual string parsed.
@@ -35,7 +35,7 @@ namespace Pidgin
             return new CIStringParser(str);
         }
     }
-    
+
     internal sealed class CIStringParser : Parser<char, string>
     {
         private readonly string _value;
@@ -57,7 +57,7 @@ namespace Pidgin
             _value = value;
         }
 
-        internal sealed override InternalResult<string> Parse(ref ParseState<char> state)
+        public sealed override InternalResult<string> Parse(ref ParseState<char> state)
         {
             var span = state.LookAhead(_value.Length);  // span.Length <= _valueTokens.Length
 

--- a/Pidgin/Parser.Token.cs
+++ b/Pidgin/Parser.Token.cs
@@ -51,7 +51,7 @@ namespace Pidgin
             _token = token;
         }
 
-        internal sealed override InternalResult<TToken> Parse(ref ParseState<TToken> state)
+        public sealed override InternalResult<TToken> Parse(ref ParseState<TToken> state)
         {
             if (!state.HasCurrent)
             {
@@ -90,7 +90,7 @@ namespace Pidgin
             _predicate = predicate;
         }
 
-        internal sealed override InternalResult<TToken> Parse(ref ParseState<TToken> state)
+        public sealed override InternalResult<TToken> Parse(ref ParseState<TToken> state)
         {
             if (!state.HasCurrent)
             {

--- a/Pidgin/Parser.Try.cs
+++ b/Pidgin/Parser.Try.cs
@@ -31,7 +31,7 @@ namespace Pidgin
             _parser = parser;
         }
 
-        internal sealed override InternalResult<T> Parse(ref ParseState<TToken> state)
+        public sealed override InternalResult<T> Parse(ref ParseState<TToken> state)
         {
             // start buffering the input
             state.PushBookmark();

--- a/Pidgin/Parser.Until.cs
+++ b/Pidgin/Parser.Until.cs
@@ -22,7 +22,7 @@ namespace Pidgin
             return terminator.Then(ReturnEmptyEnumerable)
                 .Or(this.AtLeastOnceUntil(terminator));
         }
-        
+
         /// <summary>
         /// Creates a parser which applies this parser one or more times until <paramref name="terminator"/> succeeds.
         /// Fails if this parser fails or if <paramref name="terminator"/> fails after consuming input.
@@ -57,7 +57,7 @@ namespace Pidgin
             return terminator.Then(ReturnUnit)
                 .Or(this.SkipAtLeastOnceUntil(terminator));
         }
-        
+
         /// <summary>
         /// Creates a parser which applies this parser one or more times until <paramref name="terminator"/> succeeds, discarding the results.
         /// This is more efficient than <see cref="AtLeastOnceUntil{U}(Parser{TToken, U})"/> if you don't need the results.
@@ -90,7 +90,7 @@ namespace Pidgin
         }
 
         // see comment about expecteds in ParseState.Error.cs
-        internal override InternalResult<IEnumerable<T>?> Parse(ref ParseState<TToken> state)
+        public override InternalResult<IEnumerable<T>?> Parse(ref ParseState<TToken> state)
         {
             var ts = _keepResults ? new List<T>() : null;
 

--- a/Pidgin/Parser.Whitespace.cs
+++ b/Pidgin/Parser.Whitespace.cs
@@ -33,7 +33,7 @@ namespace Pidgin
 
     internal class SkipWhitespacesParser : Parser<char, Unit>
     {
-        internal override InternalResult<Unit> Parse(ref ParseState<char> state)
+        public override InternalResult<Unit> Parse(ref ParseState<char> state)
         {
             var startingLoc = state.Location;
             var chunk = state.LookAhead(32);

--- a/Pidgin/Parser.cs
+++ b/Pidgin/Parser.cs
@@ -30,6 +30,6 @@
         // Why pass the error by reference?
         // I previously passed Result around directly, which has an Error property,
         // but copying it around turned out to be too expensive because ParseError is a large struct
-        internal abstract InternalResult<T> Parse(ref ParseState<TToken> state);
+        public abstract InternalResult<T> Parse(ref ParseState<TToken> state);
     }
 }

--- a/Pidgin/PooledArray.cs
+++ b/Pidgin/PooledArray.cs
@@ -8,7 +8,7 @@ using System.Runtime.InteropServices;
 namespace Pidgin
 {
     [StructLayout(LayoutKind.Auto)]
-    internal readonly struct PooledArray<T>
+    public readonly struct PooledArray<T>
     {
         private readonly T[] _array;
         private readonly int _length;

--- a/Pidgin/TokenStreams/ITokenStream.cs
+++ b/Pidgin/TokenStreams/ITokenStream.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace Pidgin.TokenStreams
 {
-    internal interface ITokenStream<TToken> : IDisposable
+    public interface ITokenStream<TToken> : IDisposable
     {
         int ChunkSizeHint { get; }
 


### PR DESCRIPTION
This change some access modifiers from internal to public to allow custom parsers to be implemented in external assemblies.

It also contains a new `MapWithInputRange` parser that provides the indices of the captured range.