### PR TITLE
Fix HexNum parser can't parse '9'

### DIFF
--- a/Pidgin.Tests/StringParserTests.cs
+++ b/Pidgin.Tests/StringParserTests.cs
@@ -278,6 +278,7 @@ namespace Pidgin.Tests
             }
             {
                 var parser = HexNum;
+                AssertSuccess(parser.Parse("09"), 0x09, true);
                 AssertSuccess(parser.Parse("ab"), 0xab, true);
                 AssertSuccess(parser.Parse("cd"), 0xcd, true);
                 AssertSuccess(parser.Parse("ef"), 0xef, true);

--- a/Pidgin/Parser.Number.cs
+++ b/Pidgin/Parser.Number.cs
@@ -145,7 +145,7 @@ namespace Pidgin
                     .Select(c => GetDigitValue(c))
                 : Parser<char>
                     .Token(c =>
-                        c >= '0' && c < '9'
+                        c >= '0' && c <= '9'
                         || c >= 'A' && c < 'A' + @base - 10
                         || c >= 'a' && c < 'a' + @base - 10
                     )
@@ -157,7 +157,7 @@ namespace Pidgin
                     .Select(c => GetDigitValueLong(c))
                 : Parser<char>
                     .Token(c =>
-                        c >= '0' && c < '9'
+                        c >= '0' && c <= '9'
                         || c >= 'A' && c < 'A' + @base - 10
                         || c >= 'a' && c < 'a' + @base - 10
                     )


### PR DESCRIPTION
Hi Benjamin! Thanks for releasing a great library.

This patch fix that HexNum parser can't parse character '9' problem.