### PR TITLE
Use invariant culture when parsing real number

### DIFF
--- a/Pidgin.Tests/StringParserTests.cs
+++ b/Pidgin.Tests/StringParserTests.cs
@@ -512,6 +512,13 @@ namespace Pidgin.Tests
             }
         }
 
+        [Fact, UseCulture("nb-NO")]
+        public void TestRealParserWithDifferentCultureInfo()
+        {
+            var parser = Real;
+            AssertSuccess(parser.Parse("12.345"), 12.345d, true);
+        }
+
         [Fact]
         public void TestSequence()
         {

--- a/Pidgin.Tests/UseCultureAttribute.cs
+++ b/Pidgin.Tests/UseCultureAttribute.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Globalization;
+using System.Reflection;
+using System.Threading;
+
+using Xunit.Sdk;
+
+namespace Pidgin.Tests
+{
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false, Inherited = true)]
+    public class UseCultureAttribute : BeforeAfterTestAttribute
+    {
+        readonly Lazy<CultureInfo> culture;
+        readonly Lazy<CultureInfo> uiCulture;
+
+        CultureInfo? originalCulture;
+        CultureInfo? originalUICulture;
+
+        public UseCultureAttribute(string culture)
+            : this(culture, culture) { }
+
+        public UseCultureAttribute(string culture, string uiCulture)
+        {
+            this.culture = new Lazy<CultureInfo>(() => new CultureInfo(culture));
+            this.uiCulture = new Lazy<CultureInfo>(() => new CultureInfo(uiCulture));
+        }
+
+        public CultureInfo Culture { get { return culture.Value; } }
+
+        public CultureInfo UICulture { get { return uiCulture.Value; } }
+
+        public override void Before(MethodInfo methodUnderTest)
+        {
+            originalCulture = Thread.CurrentThread.CurrentCulture;
+            originalUICulture = Thread.CurrentThread.CurrentUICulture;
+
+            Thread.CurrentThread.CurrentCulture = Culture;
+            Thread.CurrentThread.CurrentUICulture = UICulture;
+        }
+
+        public override void After(MethodInfo methodUnderTest)
+        {
+            Thread.CurrentThread.CurrentCulture = originalCulture!;
+            Thread.CurrentThread.CurrentUICulture = originalUICulture!;
+        }
+    }
+}

--- a/Pidgin/Parser.Number.cs
+++ b/Pidgin/Parser.Number.cs
@@ -1,3 +1,5 @@
+using System.Globalization;
+
 namespace Pidgin
 {
     public static partial class Parser
@@ -216,7 +218,7 @@ namespace Pidgin
                         .Or(Parser<char>.Return(Unit.Value))
                 )
                 .MapWithInput((span, _) => {
-                    var success = double.TryParse(span.ToString(), out var result);
+                    var success = double.TryParse(span.ToString(), NumberStyles.Float, CultureInfo.InvariantCulture, out var result);
                     if (success)
                     {
                         return (double?)result;


### PR DESCRIPTION
Decimal point might be culture specific, so the current Real parser fails e.g. on a Norwegian system. Specifying InvariantCulture solves the problem.