### PR TITLE
Add operator overloads for parser actions (#70)

### DIFF
--- a/Pidgin.Tests/ApiSugarParserTests.cs
+++ b/Pidgin.Tests/ApiSugarParserTests.cs
@@ -1,0 +1,31 @@
+using System.Collections.Generic;
+using Xunit;
+using static Pidgin.Parser;
+
+namespace Pidgin.Tests
+{
+    public class ApiSugarParserTests : ParserTestBase
+    {
+        [Fact]
+        public void TestOperatorOverloads()
+        {
+            TokenParser<char> semicolumn = ';';
+            Parser<char, IEnumerable<char>> terminator = semicolumn + Char('\r') + Char('\n');
+            Assert.Equal(";\r\n", terminator.ParseOrThrow(";\r\n"));
+
+            (!semicolumn).ParseOrThrow(","); // Assert no error
+
+            Parser<char, char> expr = null!;
+            //Parser<char, char> parenthesized = '(' > Rec(() => expr) < ')'; // Cause stack overflow in runtime
+            Parser<char, char> parenthesized = Char('(') > Rec(() => expr) < ')';
+            expr = Digit
+                | parenthesized
+                | Char('+');
+
+            Assert.Equal('1', expr.ParseOrThrow("1"));
+            Assert.Equal('1', expr.ParseOrThrow("(1)"));
+            Assert.Equal('1', expr.ParseOrThrow("(((1)))"));
+            Assert.Equal('+', expr.ParseOrThrow("(((+)))"));
+        }
+    }
+}

--- a/Pidgin/Parser.Operators.cs
+++ b/Pidgin/Parser.Operators.cs
@@ -1,0 +1,130 @@
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Pidgin
+{
+    public abstract partial class Parser<TToken, T>
+    {
+        /// <summary>
+        /// Creates a parser which tries to apply a first specified parser, applying a second specified parser if the first one fails without consuming any input.
+        /// The resulting parser fails if both the first parser and the second parser fail, or if the first parser fails after consuming input.
+        /// </summary>
+        /// <param name="x">The parser to apply first</param>
+        /// <param name="y">The alternative parser to apply if <paramref name="x"/> parser fails without consuming any input</param>
+        /// <returns>A parser which tries to apply <paramref name="x"/>, and then applies <paramref name="y"/> if <paramref name="x"/> fails without consuming any input.</returns>
+        public static Parser<TToken, T> operator |(Parser<TToken, T> x, Parser<TToken, T> y)
+        {
+            if (x == null)
+            {
+                throw new ArgumentNullException(nameof(x));
+            }
+            if (y == null)
+            {
+                throw new ArgumentNullException(nameof(y));
+            }
+            return x.Or(y);
+        }
+
+        /// <summary>
+        /// Creates a parser which applies specified parsers in left-to-right order.
+        /// The resulting parser returns the result of the second parser, ignoring the result of the first one.
+        /// </summary>
+        public static Parser<TToken, T> operator >(Parser<TToken, T> x, Parser<TToken, T> y)
+        {
+            if (x == null)
+            {
+                throw new ArgumentNullException(nameof(x));
+            }
+            if (y == null)
+            {
+                throw new ArgumentNullException(nameof(y));
+            }
+            return x.Then(y);
+        }
+
+        /// <summary>
+        /// Creates a parser which applies specified parsers in left-to-right order.
+        /// The resulting parser returns the result of the first parser, ignoring the result of the second one.
+        /// </summary>
+        public static Parser<TToken, T> operator <(Parser<TToken, T> x, Parser<TToken, T> y)
+        {
+            if (x == null)
+            {
+                throw new ArgumentNullException(nameof(x));
+            }
+            if (y == null)
+            {
+                throw new ArgumentNullException(nameof(y));
+            }
+            return x.Before(y);
+        }
+
+        public static Parser<TToken, T> operator <(Parser<TToken, T> parser, TToken token)
+        {
+            if (parser == null)
+            {
+                throw new ArgumentNullException(nameof(parser));
+            }
+            var tokenParser = Parser<TToken>.Token(token);
+            return parser.Before(tokenParser);
+        }
+
+        public static Parser<TToken, T> operator >(Parser<TToken, T> parser, TToken token)
+        {
+            if (typeof(T) == typeof(TToken))
+            {
+                var tokenParser = Parser<TToken>.Token(token);
+                return (Parser<TToken, T>)(object)parser.Then(tokenParser);
+            }
+            throw new NotSupportedException("[TBD] Supported only if `T == TToken`");
+        }
+
+        public static Parser<TToken, T> operator <(TToken token, Parser<TToken, T> parser)
+        {
+            return parser > token;
+        }
+
+        public static Parser<TToken, T> operator >(TToken token, Parser<TToken, T> parser)
+        {
+            return parser < token;
+        }
+
+        public static Parser<TToken, IEnumerable<T>> operator +(Parser<TToken, T> x, Parser<TToken, T> y)
+        {
+            if (x == null)
+            {
+                throw new ArgumentNullException(nameof(x));
+            }
+            if (y == null)
+            {
+                throw new ArgumentNullException(nameof(y));
+            }            
+            return Parser<TToken>.Sequence(x, y);
+        }
+
+        public static Parser<TToken, IEnumerable<T>> operator +(Parser<TToken, IEnumerable<T>> sequence, Parser<TToken, T> newElement)
+        {
+            if (sequence == null)
+            {
+                throw new ArgumentNullException(nameof(sequence));
+            }
+            if (newElement == null)
+            {
+                throw new ArgumentNullException(nameof(newElement));
+            }
+            if (sequence is SequenceParser<TToken, T> seqParser)
+            {
+                return new SequenceParser<TToken, T>(seqParser.Parsers.Append(newElement).ToArray());
+            }
+            throw new NotSupportedException("TODO");
+        }
+
+        public static Parser<TToken, Unit> operator !(Parser<TToken, T> parser)
+        {
+            return Parser.Not(parser);
+        }
+    }
+}

--- a/Pidgin/Parser.Sequence.cs
+++ b/Pidgin/Parser.Sequence.cs
@@ -77,6 +77,7 @@ namespace Pidgin
     internal sealed class SequenceParser<TToken, T> : Parser<TToken, IEnumerable<T>>
     {
         private readonly Parser<TToken, T>[] _parsers;
+        internal IReadOnlyCollection<Parser<TToken, T>> Parsers => _parsers;
 
         public SequenceParser(Parser<TToken, T>[] parsers)
         {

--- a/Pidgin/Parser.Token.cs
+++ b/Pidgin/Parser.Token.cs
@@ -73,6 +73,9 @@ namespace Pidgin
             result = token;
             return true;
         }
+
+        public static implicit operator TokenParser<TToken>(TToken token)
+            => new TokenParser<TToken>(token);
     }
 
     internal sealed class PredicateTokenParser<TToken> : Parser<TToken, TToken>


### PR DESCRIPTION
Hello!
First, thank you for this awesome lib!
I'd testing it within pet project where monsters like _ANTLR_ and _Hime_ are overkill.
Declare parser with solely C# is really good but I found myself uncomfortable when some native actions like "OR" or "NOT" should be declared as method calls even for simple cases.
Found similar issue (#70), but it was long time ago and author seems to disappear.

**This PR is proof of concept operator overloads API.**

I've implemented hastily some overloads to show you API mockup in `ApiSugarParserTests`. Everything in this PR is discussible and with high probability should be improved before land into the next release.

_"Not" operator_ is quite straight forward. Can't imagine what to improve :)
_"Plus" operator_ from original issue (#70). This feature needs better design as you and will cause changes in `SequenceParser's`. Maybe we don't really need it.
_"Or" operator_ is why I'm originally here. It also need some additional work to cover advanced cases (e.g. when apply `not`, `optional` etc. for one of operands)
_"More" and "Less" operators_ is very questionable. It looks good to have some short ways to describe `Before` and `Than` but this operators can confuse some users. Bitshifts (`>>`/`<<`) operators can play here _a little_ better but it's forbidden to use anything but `int` as second argument for these operators.

Any thought here are very welcome!
Regards, Andrei.