### PR TITLE
Add Farkle benchmarks.

### DIFF
--- a/Pidgin.Bench/ExpressionBench.cs
+++ b/Pidgin.Bench/ExpressionBench.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Configs;
 using Pidgin.Expression;
@@ -32,6 +33,7 @@ namespace Pidgin.Bench
                 Parser.Num,
                 new[] { new[] { infixR } }
             );
+            RuntimeHelpers.RunClassConstructor(typeof(FarkleParsers.FarkleExpressionParser).TypeHandle);
         }
 
         [Benchmark, BenchmarkCategory("Long")]
@@ -54,6 +56,16 @@ namespace Pidgin.Bench
         {
             Pidgin.Bench.FParsec.ExpressionParser.parseR(_bigExpression);
         }
+        [Benchmark, BenchmarkCategory("Long")]
+        public void LongInfixL_Farkle()
+        {
+            FarkleParsers.FarkleExpressionParser.ParseL(_bigExpression);
+        }
+        [Benchmark, BenchmarkCategory("Long")]
+        public void LongInfixR_Farkle()
+        {
+            FarkleParsers.FarkleExpressionParser.ParseR(_bigExpression);
+        }
 
         [Benchmark, BenchmarkCategory("Short")]
         public void ShortInfixL_Pidgin()
@@ -74,6 +86,16 @@ namespace Pidgin.Bench
         public void ShortInfixR_FParsec()
         {
             Pidgin.Bench.FParsec.ExpressionParser.parseR("1+1");
+        }
+        [Benchmark, BenchmarkCategory("Short")]
+        public void ShortInfixL_Farkle()
+        {
+            FarkleParsers.FarkleExpressionParser.ParseL("1+1");
+        }
+        [Benchmark, BenchmarkCategory("Short")]
+        public void ShortInfixR_Farkle()
+        {
+            FarkleParsers.FarkleExpressionParser.ParseR("1+1");
         }
     }
 }

--- a/Pidgin.Bench/FarkleParsers/FarkleExpressionParser.cs
+++ b/Pidgin.Bench/FarkleParsers/FarkleExpressionParser.cs
@@ -1,0 +1,42 @@
+﻿using Farkle;
+using Farkle.Builder;
+using Farkle.Builder.OperatorPrecedence;
+using System;
+
+namespace Pidgin.Bench.FarkleParsers
+{
+    internal static class FarkleExpressionParser
+    {
+        private static readonly RuntimeFarkle<int> _parserL = CreateParser(AssociativityType.LeftAssociative);
+        private static readonly RuntimeFarkle<int> _parserR = CreateParser(AssociativityType.RightAssociative);
+
+        private static RuntimeFarkle<int> CreateParser(AssociativityType associativity)
+        {
+            var number = Terminals.Int32("Number");
+            var expr = Nonterminal.Create<int>("Expression");
+            expr.SetProductions(
+                expr.Extended().Append("+").Extend(expr).Finish((x1, x2) => x1 + x2),
+                number.AsIs()
+            );
+
+            var opScope = new OperatorScope(new AssociativityGroup(associativity, "+"));
+            return expr.WithOperatorScope(opScope).Build();
+        }
+
+        private static int ParseOrThrow(string str, RuntimeFarkle<int> parser)
+        {
+            var result = parser.Parse(str);
+            if (result.IsOk)
+            {
+                return result.ResultValue;
+            }
+            else
+            {
+                throw new Exception(result.ErrorValue.ToString());
+            }
+        }
+
+        public static int ParseL(string str) => ParseOrThrow(str, _parserL);
+        public static int ParseR(string str) => ParseOrThrow(str, _parserR);
+    }
+}

--- a/Pidgin.Bench/FarkleParsers/FarkleJsonParser.cs
+++ b/Pidgin.Bench/FarkleParsers/FarkleJsonParser.cs
@@ -1,0 +1,90 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using Farkle;
+using Farkle.Builder;
+using Pidgin.Examples.Json;
+
+namespace Pidgin.Bench.FarkleParsers
+{
+    public static class FarkleJsonParser
+    {
+        private sealed class ImmutableArrayBuilder<T> : ICollection<T>
+        {
+            private readonly ImmutableArray<T>.Builder _builder = ImmutableArray.CreateBuilder<T>();
+            public IEnumerator<T> GetEnumerator() => _builder.GetEnumerator();
+            IEnumerator IEnumerable.GetEnumerator() => ((IEnumerable)_builder).GetEnumerator();
+            public void Add(T item) => _builder.Add(item);
+            public void Clear() => _builder.Clear();
+            public bool Contains(T item) => _builder.Contains(item);
+            public void CopyTo(T[] array, int arrayIndex) => _builder.CopyTo(array, arrayIndex);
+            public bool Remove(T item) => _builder.Remove(item);
+            public int Count => _builder.Count;
+            public bool IsReadOnly => ((ICollection<T>) _builder).IsReadOnly;
+
+            public ImmutableArray<T> ToImmutable() => _builder.ToImmutable();
+        }
+
+        private sealed class ImmutableDictionaryBuilder<TKey, TValue> : ICollection<KeyValuePair<TKey, TValue>> where TKey: notnull
+        {
+            private readonly ImmutableDictionary<TKey, TValue>.Builder _builder = ImmutableDictionary.CreateBuilder<TKey, TValue>();
+            public IEnumerator<KeyValuePair<TKey, TValue>> GetEnumerator() => _builder.GetEnumerator();
+            IEnumerator IEnumerable.GetEnumerator() => ((IEnumerable)_builder).GetEnumerator();
+            public void Add(KeyValuePair<TKey, TValue> item) => _builder.Add(item);
+            public void Clear() => _builder.Clear();
+            public bool Contains(KeyValuePair<TKey, TValue> item) => _builder.Contains(item);
+            public void CopyTo(KeyValuePair<TKey, TValue>[] array, int arrayIndex) => ((ICollection<KeyValuePair<TKey, TValue>>)_builder).CopyTo(array, arrayIndex);
+            public bool Remove(KeyValuePair<TKey, TValue> item) => _builder.Remove(item);
+            public int Count => _builder.Count;
+            public bool IsReadOnly => ((ICollection<KeyValuePair<TKey, TValue>>)_builder).IsReadOnly;
+
+            public ImmutableDictionary<TKey, TValue> ToImmutable() => _builder.ToImmutable();
+        }
+
+        private static DesigntimeFarkle<TTo> SelectBetween<TFrom, TTo>(this DesigntimeFarkle<TFrom> df, string from, string to, Func<TFrom, TTo> f) where TTo : notnull =>
+            Nonterminal.Create(df.Name, from.Appended().Extend(df).Append(to).Finish(f));
+
+        public static readonly DesigntimeFarkle<IJson> Designtime;
+        public static readonly RuntimeFarkle<IJson> Runtime;
+
+        static FarkleJsonParser()
+        {
+            var json = Nonterminal.Create<IJson>("JSON");
+            var @string = Terminal.Create("String",
+                (_, data) => data[1..^1].ToString(),
+                Regex.FromRegexString("\"[^\"]*\""));
+
+            var jsonArray =
+                json.SeparatedBy<IJson, ImmutableArrayBuilder<IJson>>(Terminal.Literal(","), true)
+                    .Rename("Array Body")
+                    .Optional()
+                    .SelectBetween("[", "]", x => (IJson) new JsonArray(x?.ToImmutable() ?? ImmutableArray<IJson>.Empty))
+                    .Rename("Array");
+
+            var jsonObject =
+                Nonterminal.Create("Object Member",
+                        @string.Extended().Append(":").Extend(json).Finish(KeyValuePair.Create))
+                    .SeparatedBy<KeyValuePair<string, IJson>, ImmutableDictionaryBuilder<string, IJson>>(Terminal.Literal(","), true)
+                    .Rename("Object Body")
+                    .Optional()
+                    .SelectBetween("{", "}", x => (IJson) new JsonObject(x?.ToImmutable() ?? ImmutableDictionary<string, IJson>.Empty))
+                    .Rename("Object");
+
+            json.SetProductions(
+                @string.Extended().Finish(x => (IJson)new JsonString(x)),
+                jsonArray.AsIs(),
+                jsonObject.AsIs());
+
+            Designtime = json.CaseSensitive();
+            Runtime = Designtime.Build();
+        }
+
+        public static IJson Parse(string str)
+        {
+            var result = Runtime.Parse(str);
+            if (result.IsOk) return result.ResultValue;
+            throw new Exception(result.ErrorValue.ToString());
+        }
+    }
+}

--- a/Pidgin.Bench/JsonBench.cs
+++ b/Pidgin.Bench/JsonBench.cs
@@ -2,8 +2,10 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Configs;
+using Pidgin.Bench.FarkleParsers;
 using Pidgin.Bench.SpracheParsers;
 using Pidgin.Bench.SuperpowerParsers;
 using Pidgin.Examples.Json;
@@ -27,6 +29,7 @@ namespace Pidgin.Bench
             _longJson = BuildJson(256, 1, 1).ToString()!;
             _wideJson = BuildJson(1, 1, 256).ToString()!;
             _deepJson = BuildJson(1, 256, 1).ToString()!;
+            RuntimeHelpers.RunClassConstructor(typeof(FarkleJsonParser).TypeHandle);
         }
 
         [Benchmark(Baseline = true), BenchmarkCategory("Big")]
@@ -49,6 +52,8 @@ namespace Pidgin.Bench
         {
             Pidgin.Bench.FParsec.JsonParser.parse(_bigJson);
         }
+        [Benchmark, BenchmarkCategory("Big")]
+        public void BigJson_Farkle() => FarkleJsonParser.Parse(_bigJson);
 
         [Benchmark(Baseline = true), BenchmarkCategory("Long")]
         public void LongJson_Pidgin()
@@ -70,6 +75,8 @@ namespace Pidgin.Bench
         {
             Pidgin.Bench.FParsec.JsonParser.parse(_longJson);
         }
+        [Benchmark, BenchmarkCategory("Long")]
+        public void LongJson_Farkle() => FarkleJsonParser.Parse(_longJson);
 
         [Benchmark(Baseline = true), BenchmarkCategory("Deep")]
         public void DeepJson_Pidgin()
@@ -92,6 +99,8 @@ namespace Pidgin.Bench
         {
             Pidgin.Bench.FParsec.JsonParser.parse(_deepJson);
         }
+        [Benchmark, BenchmarkCategory("Deep")]
+        public void DeepJson_Farkle() => FarkleJsonParser.Parse(_deepJson);
 
         [Benchmark(Baseline = true), BenchmarkCategory("Wide")]
         public void WideJson_Pidgin()
@@ -113,7 +122,9 @@ namespace Pidgin.Bench
         {
             Pidgin.Bench.FParsec.JsonParser.parse(_wideJson);
         }
-        
+        [Benchmark, BenchmarkCategory("Wide")]
+        public void WideJson_Farkle() => FarkleJsonParser.Parse(_wideJson);
+
         private static IJson BuildJson(int length, int depth, int width)
             => new JsonArray(
                 Enumerable.Repeat(1, length)

--- a/Pidgin.Bench/Pidgin.Bench.csproj
+++ b/Pidgin.Bench/Pidgin.Bench.csproj
@@ -14,6 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Farkle" Version="6.4.0" />
     <PackageReference Include="Sprache" Version="2.3.1" />
     <PackageReference Include="Superpower" Version="2.3.0" />
     <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />


### PR DESCRIPTION
Hello, I have created a parsing library called [Farkle](https://teo-tsirpanis.github.io/Farkle). Its API bears a strong resemblance to parser combinators, but in contrast with ordinary parser combinator libraries like Pidgin, Sprache and FParsec, it uses bottom-up LALR(1) parsing under the hood. It would be fun to add it to the benchmarks, and would help tuning the performance of both Farkle and Pidgin.

I ran it on my machine, and the enclosed results are interesting. In the JSON benchmarks, Farkle is a solid contender, finishing always in the top three in both time and memory, and finishing first in the deep JSON files benchmark. In the expression benchmarks, Farkle always finishes second in time, but uses significantly more memory than Pidgin and FParsec.

Let me know if you have any questions.

<details>
<summary>JSON benchmarks.</summary>

```
BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19044
Intel Core i7-7700HQ CPU 2.80GHz (Kaby Lake), 1 CPU, 8 logical and 4 physical cores
.NET Core SDK=7.0.100-preview.2.22153.17
  [Host]     : .NET Core 5.0.15 (CoreCLR 5.0.1522.11506, CoreFX 5.0.1522.11506), X64 RyuJIT
  DefaultJob : .NET Core 5.0.15 (CoreCLR 5.0.1522.11506, CoreFX 5.0.1522.11506), X64 RyuJIT
```

|              Method |       Mean |    Error |    StdDev |     Median | Ratio | RatioSD |     Gen 0 |    Gen 1 | Gen 2 |  Allocated |
|-------------------- |-----------:|---------:|----------:|-----------:|------:|--------:|----------:|---------:|------:|-----------:|
|      BigJson_Pidgin |   456.5 us |  5.86 us |   5.20 us |   456.0 us |  1.00 |    0.00 |   33.2031 |        - |     - |   101.7 KB |
|     BigJson_Sprache | 3,579.2 us | 71.09 us | 157.54 us | 3,575.0 us |  7.81 |    0.31 | 1746.0938 |        - |     - | 5349.63 KB |
|  BigJson_Superpower | 2,277.5 us | 37.81 us |  33.52 us | 2,284.5 us |  4.99 |    0.10 |  296.8750 |        - |     - |  913.43 KB |
|     BigJson_FParsec |   361.2 us |  7.22 us |  15.70 us |   359.1 us |  0.81 |    0.04 |   76.6602 |        - |     - |  235.93 KB |
|      BigJson_Farkle |   545.6 us |  7.40 us |   6.92 us |   546.7 us |  1.20 |    0.02 |   68.3594 |        - |     - |  209.54 KB |
|                     |            |          |           |            |       |         |           |          |       |            |
|     LongJson_Pidgin |   414.5 us |  8.13 us |  11.40 us |   412.9 us |  1.00 |    0.00 |   33.6914 |        - |     - |  104.25 KB |
|    LongJson_Sprache | 2,783.8 us | 55.17 us |  95.17 us | 2,761.2 us |  6.76 |    0.30 | 1406.2500 |        - |     - | 4311.36 KB |
| LongJson_Superpower | 1,809.0 us | 13.58 us |  12.04 us | 1,806.1 us |  4.34 |    0.10 |  230.4688 |        - |     - |  706.79 KB |
|    LongJson_FParsec |   314.0 us |  5.43 us |   8.13 us |   311.2 us |  0.76 |    0.03 |   74.7070 |        - |     - |   230.3 KB |
|     LongJson_Farkle |   449.6 us |  4.60 us |   4.08 us |   448.6 us |  1.08 |    0.03 |   57.1289 |        - |     - |  175.31 KB |
|                     |            |          |           |            |       |         |           |          |       |            |
|     DeepJson_Pidgin |   533.0 us |  9.77 us |  26.92 us |   524.8 us |  1.00 |    0.00 |   66.4063 |        - |     - |  205.29 KB |
|    DeepJson_Sprache | 3,108.7 us | 63.99 us | 183.59 us | 3,074.9 us |  5.86 |    0.47 |  730.4688 | 222.6563 |     - | 2946.56 KB |
|    DeepJson_FParsec |   328.3 us |  6.54 us |  17.23 us |   325.7 us |  0.62 |    0.04 |   62.0117 |        - |     - |  190.43 KB |
|     DeepJson_Farkle |   318.7 us |  5.73 us |   8.92 us |   315.9 us |  0.57 |    0.03 |   48.3398 |        - |     - |  148.17 KB |
|                     |            |          |           |            |       |         |           |          |       |            |
|     WideJson_Pidgin |   262.9 us |  4.64 us |   4.34 us |   261.6 us |  1.00 |    0.00 |   15.6250 |        - |     - |   48.42 KB |
|    WideJson_Sprache | 1,580.5 us | 25.60 us |  34.17 us | 1,572.4 us |  6.05 |    0.17 |  912.1094 |        - |     - | 2797.28 KB |
| WideJson_Superpower | 1,145.3 us | 22.73 us |  31.86 us | 1,139.4 us |  4.38 |    0.14 |  148.4375 |        - |     - |  459.74 KB |
|    WideJson_FParsec |   213.2 us |  4.01 us |   4.29 us |   211.8 us |  0.81 |    0.02 |   33.9355 |        - |     - |  104.63 KB |
|     WideJson_Farkle |   350.5 us |  6.99 us |  18.29 us |   345.2 us |  1.32 |    0.06 |   34.1797 |        - |     - |  105.56 KB |
</details>

<details>
<summary>Expression benchmarks.</summary>

```
BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19044
Intel Core i7-7700HQ CPU 2.80GHz (Kaby Lake), 1 CPU, 8 logical and 4 physical cores
.NET Core SDK=7.0.100-preview.2.22153.17
  [Host]     : .NET Core 5.0.15 (CoreCLR 5.0.1522.11506, CoreFX 5.0.1522.11506), X64 RyuJIT
  DefaultJob : .NET Core 5.0.15 (CoreCLR 5.0.1522.11506, CoreFX 5.0.1522.11506), X64 RyuJIT
```

|              Method |         Mean |       Error |       StdDev | Ratio | RatioSD |   Gen 0 | Gen 1 | Gen 2 | Allocated |
|-------------------- |-------------:|------------:|-------------:|------:|--------:|--------:|------:|------:|----------:|
|   LongInfixL_Pidgin | 426,214.4 ns | 8,470.92 ns | 12,678.88 ns | 11.78 |    0.34 |       - |     - |     - |     136 B |
|   LongInfixR_Pidgin | 422,279.7 ns | 1,854.75 ns |  1,644.19 ns | 11.50 |    0.05 |       - |     - |     - |     128 B |
|  LongInfixL_FParsec |  36,710.6 ns |   107.03 ns |     89.37 ns |  1.00 |    0.00 |  0.0610 |     - |     - |     200 B |
|  LongInfixR_FParsec |  42,116.8 ns |   227.04 ns |    212.38 ns |  1.15 |    0.01 |  0.0610 |     - |     - |     200 B |
|   LongInfixL_Farkle | 309,182.5 ns |   908.00 ns |    804.92 ns |  8.42 |    0.04 | 51.2695 |     - |     - |  160976 B |
|   LongInfixR_Farkle | 320,691.2 ns | 1,242.24 ns |  1,161.99 ns |  8.73 |    0.03 | 66.4063 |     - |     - |  208832 B |
|                     |              |             |              |       |         |         |       |       |           |
|  ShortInfixL_Pidgin |   1,420.0 ns |     5.79 ns |      5.13 ns | 12.88 |    0.08 |  0.0420 |     - |     - |     136 B |
|  ShortInfixR_Pidgin |   1,427.4 ns |     5.90 ns |      5.52 ns | 12.94 |    0.09 |  0.0401 |     - |     - |     128 B |
| ShortInfixL_FParsec |     110.3 ns |     0.54 ns |      0.48 ns |  1.00 |    0.00 |  0.0637 |     - |     - |     200 B |
| ShortInfixR_FParsec |     109.9 ns |     0.17 ns |      0.15 ns |  1.00 |    0.00 |  0.0637 |     - |     - |     200 B |
|  ShortInfixL_Farkle |     679.9 ns |     1.70 ns |      1.59 ns |  6.17 |    0.03 |  0.4129 |     - |     - |    1296 B |
|  ShortInfixR_Farkle |     679.8 ns |     2.38 ns |      2.11 ns |  6.17 |    0.04 |  0.4129 |     - |     - |    1296 B |
</details>