### PR TITLE
A parser to recover from exceptions

### DIFF
--- a/Pidgin.Tests/CatchTestException1.cs
+++ b/Pidgin.Tests/CatchTestException1.cs
@@ -1,0 +1,20 @@
+﻿using System;
+
+namespace Pidgin.Tests;
+
+public class CatchTest1Exception : Exception
+{
+    public CatchTest1Exception()
+    {
+    }
+
+    public CatchTest1Exception(string message)
+        : base(message)
+    {
+    }
+
+    public CatchTest1Exception(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+}

--- a/Pidgin.Tests/CatchTestException2.cs
+++ b/Pidgin.Tests/CatchTestException2.cs
@@ -1,0 +1,20 @@
+﻿using System;
+
+namespace Pidgin.Tests;
+
+public class CatchTest2Exception : Exception
+{
+    public CatchTest2Exception()
+    {
+    }
+
+    public CatchTest2Exception(string message)
+        : base(message)
+    {
+    }
+
+    public CatchTest2Exception(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+}

--- a/Pidgin.Tests/CatchTests.cs
+++ b/Pidgin.Tests/CatchTests.cs
@@ -1,0 +1,116 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+using Xunit;
+
+namespace Pidgin.Tests;
+
+public partial class CatchTests : ParserTestBase
+{
+    [Fact]
+    public void TestString()
+    {
+        DoTest((p, x) => p.Parse(x), x => x, x => x);
+    }
+
+    [Fact]
+    public void TestList()
+    {
+        DoTest((p, x) => p.Parse(x), x => x, x => x.ToCharArray());
+    }
+
+    [Fact]
+    public void TestReadOnlyList()
+    {
+        DoTest((p, x) => p.ParseReadOnlyList(x), x => x, x => x.ToCharArray());
+    }
+
+    [Fact]
+    public void TestEnumerator()
+    {
+        DoTest((p, x) => p.Parse(x), x => x, x => x.AsEnumerable());
+    }
+
+    [Fact]
+    public void TestReader()
+    {
+        DoTest((p, x) => p.Parse(x), x => x, x => new StringReader(x));
+    }
+
+    [Fact]
+    public void TestStream()
+    {
+        DoTest((p, x) => p.Parse(x), Encoding.ASCII.GetBytes, x => new MemoryStream(Encoding.ASCII.GetBytes(x)));
+    }
+
+    [Fact]
+    public void TestSpan()
+    {
+        DoTest((p, x) => p.Parse(x.Span), x => x, x => x.AsMemory());
+    }
+
+    private static void DoTest<TToken, TInput>(
+        Func<Parser<TToken, IEnumerable<TToken>>, TInput, Result<TToken, IEnumerable<TToken>>> parseFunc,
+        Func<string, IEnumerable<TToken>> render,
+        Func<string, TInput> toInput
+    )
+        where TToken : IEquatable<TToken>
+    {
+        {
+            var parser =
+                Parser<TToken>.Sequence(render("foo"))
+                .Or(Parser<TToken>.Sequence(render("1throw"))
+                    .Then(Parser<TToken>.Sequence(render("after"))
+                        .RecoverWith(e => throw new CatchTest1Exception())))
+                .Or(Parser<TToken>.Sequence(render("2throw"))
+                    .Then(Parser<TToken>.Sequence(render("after"))
+                        .RecoverWith(e => throw new CatchTest2Exception())))
+                .Catch<CatchTest1Exception>((e, i) => Parser<TToken>.Any.Repeat(i))
+                .Catch<CatchTest2Exception>((e) => Parser<TToken>.Any.Many());
+            AssertSuccess(parseFunc(parser, toInput("foobar")), render("foo"));
+            AssertSuccess(parseFunc(parser, toInput("1throwafter")), render("after"));
+            AssertSuccess(parseFunc(parser, toInput("1throwandrecover")), render("1throwa")); // it should have consumed the "1throwa" but then backtracked
+            AssertSuccess(parseFunc(parser, toInput("1throwaftsomemore")), render("1throwaft")); // it should have consumed the "1throwaft" but then backtracked
+            AssertSuccess(parseFunc(parser, toInput("2throwafter")), render("after"));
+            AssertSuccess(parseFunc(parser, toInput("2throwandrecover")), render("2throwandrecover")); // it should have consumed the "2throwa" but then backtracked
+            AssertSuccess(parseFunc(parser, toInput("2throwaftsomemore")), render("2throwaftsomemore")); // it should have consumed the "2throwaft" but then backtracked
+            AssertFailure(
+                parseFunc(parser, toInput("f")),
+                new ParseError<TToken>(
+                    Maybe.Nothing<TToken>(),
+                    true,
+                    ImmutableArray.Create(new Expected<TToken>(ImmutableArray.CreateRange(render("foo")))),
+                    1,
+                    SourcePosDelta.OneCol,
+                    null
+                )
+            );
+            AssertFailure(
+                parseFunc(parser, toInput("")),
+                new ParseError<TToken>(
+                    Maybe.Nothing<TToken>(),
+                    true,
+                    ImmutableArray.Create(new Expected<TToken>(ImmutableArray.CreateRange(render("foo"))), new Expected<TToken>(ImmutableArray.CreateRange(render("1throw"))), new Expected<TToken>(ImmutableArray.CreateRange(render("2throw")))),
+                    0,
+                    SourcePosDelta.Zero,
+                    null
+                )
+            );
+            AssertFailure(
+                parseFunc(parser, toInput("foul")),
+                new ParseError<TToken>(
+                    Maybe.Just(render("u").Single()),
+                    false,
+                    ImmutableArray.Create(new Expected<TToken>(ImmutableArray.CreateRange(render("foo")))),
+                    2,
+                    new SourcePosDelta(0, 2),
+                    null
+                )
+            );
+        }
+    }
+}

--- a/Pidgin/Parser.Catch.cs
+++ b/Pidgin/Parser.Catch.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Pidgin;
+
+public abstract partial class Parser<TToken, T>
+{
+    /// <summary>
+    /// Creates a parser which runs the current parser, running <paramref name="errorHandler"/> if it throws <typeparamref name="TException"/>.
+    /// </summary>
+    /// <typeparam name="TException">The exception to catch.</typeparam>
+    /// <param name="errorHandler">A function which returns a parser to apply when the current parser throws <typeparamref name="TException"/>.</param>
+    /// <returns>A parser twhich runs the current parser, running <paramref name="errorHandler"/> if it throws <typeparamref name="TException"/>.</returns>
+    public Parser<TToken, T> Catch<TException>(Func<TException, Parser<TToken, T>> errorHandler)
+        where TException : Exception
+    {
+        return Catch((TException e, int _) => errorHandler(e));
+    }
+
+    /// <summary>
+    /// Creates a parser which runs the current parser, calling <paramref name="errorHandler"/> with the number of inputs consumed
+    /// by the current parser until failure if it throws <typeparamref name="TException"/>.
+    /// </summary>
+    /// <typeparam name="TException">The exception to catch.</typeparam>
+    /// <param name="errorHandler">A function which returns a parser to apply when the current parser throws <typeparamref name="TException"/>.</param>
+    /// <returns>A parser twhich runs the current parser, running <paramref name="errorHandler"/> if it throws <typeparamref name="TException"/>.</returns>
+    public Parser<TToken, T> Catch<TException>(Func<TException, int, Parser<TToken, T>> errorHandler)
+        where TException : Exception
+    {
+        return new CatchParser<TToken, T, TException>(this, errorHandler);
+    }
+}
+
+/// <summary>
+/// A parser to wrap previous parser and catch exceptions of specified type and provides
+/// an opportunity to recover.
+/// </summary>
+/// <remarks>
+/// The previous parser may e.g. throw an exception in a delegate used with
+/// <see cref="Parser{TToken, T}.Select{U}(Func{T, U})"/>.
+/// </remarks>
+/// <typeparam name="TToken">The type of tokens in the parser's input stream.</typeparam>
+/// <typeparam name="T">The return type of the parser.</typeparam>
+/// <typeparam name="TException">Exception type to catch.</typeparam>
+internal sealed class CatchParser<TToken, T, TException> : Parser<TToken, T>
+    where TException : Exception
+{
+    private readonly Parser<TToken, T> _parser;
+
+    private readonly Func<TException, int, Parser<TToken, T>> _errorHandler;
+
+    public CatchParser(Parser<TToken, T> parser, Func<TException, int, Parser<TToken, T>> errorHandler)
+    {
+        _errorHandler = errorHandler;
+        _parser = parser;
+    }
+
+    public override bool TryParse(ref ParseState<TToken> state, ref PooledList<Expected<TToken>> expecteds, [MaybeNullWhen(false)] out T result)
+    {
+        var bookmark = state.Bookmark();
+        try
+        {
+            var success = _parser.TryParse(ref state, ref expecteds, out result);
+            state.DiscardBookmark(bookmark);
+
+            return success;
+        }
+        catch (TException e)
+        {
+            var count = state.Location - bookmark;
+            state.Rewind(bookmark);
+
+            return _errorHandler(e, count).TryParse(ref state, ref expecteds, out result);
+        }
+    }
+}


### PR DESCRIPTION
I created `CatchParser` originally because I wanted to bail out from a delegate/lambda used with `.Select()` and be able to report sensible errors. I then found it to be a convenient means to bail out from deeply nested parsing, i.e. when using `ExpressionParser` and do common error handling and reporting on a higher level.

Before preparing this pull request I did however take a step back and achieved the same goal instead by letting errors detected deep down bubble up to higher level context by letting parsers return an error result instead of just failing. It turned out to work equally well or even better and make my code easier to follow as it does not skip out of deeply nested calls using `try`-`catch`.

With that said, I would generally recommend to design parsers so that they report errors or other events to outer contexts by returning results to represent such situations before resorting to using `CatchParser`. I can't think of any situation that could not be dealt with using what is already available in Pidgin using the strategy to basically never let a composition of nested parsers just fail but return a result representing the failure instead.

Nevertheless since I already wrote it and there may be use cases that I didn't think of, here it is. Feel free to accept or reject it.