### PR TITLE
Restored netstandard2.0 support

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,8 +10,3 @@ insert_final_newline = true
 
 [*.Generated.cs]
 generated_code = true
-
-[*.{cs,vb}]
-dotnet_diagnostic.CA1510.severity = none
-dotnet_diagnostic.CA1512.severity = none
-dotnet_diagnostic.CA1859.severity = none

--- a/.editorconfig
+++ b/.editorconfig
@@ -10,3 +10,8 @@ insert_final_newline = true
 
 [*.Generated.cs]
 generated_code = true
+
+[*.{cs,vb}]
+dotnet_diagnostic.CA1510.severity = none
+dotnet_diagnostic.CA1512.severity = none
+dotnet_diagnostic.CA1859.severity = none

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,21 +1,25 @@
+@ -1,20 +1,21 @@
 <Project>
-  <ItemGroup>
-    <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
-    <PackageVersion Include="Benjamin.Pizza.DocTest" Version="1.1.0" />
-    <PackageVersion Include="FParsec" Version="1.1.1" />
-    <PackageVersion Include="Meziantou.Polyfill" Version="1.0.110" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-    <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.3.2" />
-    <PackageVersion Include="Microsoft.Testing.Extensions.TrxReport" Version="2.0.2" />
-    <PackageVersion Include="Sprache" Version="2.3.1" />
-    <PackageVersion Include="Superpower" Version="3.1.0" />
-    <PackageVersion Include="System.Collections.Immutable" Version="10.0.5" />
-    <PackageVersion Include="System.Memory" Version="4.6.3" />
-    <PackageVersion Include="System.Runtime.CompilerServices.Unsafe" Version="6.1.2" />
-    <PackageVersion Include="xunit.v3.mtp-v2" Version="3.2.2" />
-  </ItemGroup>
-  <ItemGroup>
-    <GlobalPackageReference Include="Benjamin.Pizza.BuildScripts" Version="2.4.0" />
-    <GlobalPackageReference Include="StyleCop.Analyzers" Version="1.1.118" />
-  </ItemGroup>
+
+    <ItemGroup>
+        <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
+        <PackageVersion Include="Benjamin.Pizza.DocTest" Version="1.1.0" />
+        <PackageVersion Include="FParsec" Version="1.1.1" />
+		<PackageVersion Include="Meziantou.Polyfill" Version="1.0.110" />
+        <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+        <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.3.2" />
+        <PackageVersion Include="Microsoft.Testing.Extensions.TrxReport" Version="2.0.2" />
+        <PackageVersion Include="Sprache" Version="2.3.1" />
+        <PackageVersion Include="Superpower" Version="3.1.0" />
+        <PackageVersion Include="System.Collections.Immutable" Version="10.0.5" />
+        <PackageVersion Include="System.Memory" Version="4.6.3" />
+        <PackageVersion Include="System.Runtime.CompilerServices.Unsafe" Version="6.1.2" />
+        <PackageVersion Include="xunit.v3.mtp-v2" Version="3.2.2" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <GlobalPackageReference Include="Benjamin.Pizza.BuildScripts" Version="2.4.0" />
+        <GlobalPackageReference Include="StyleCop.Analyzers" Version="1.1.118" />
+    </ItemGroup>
+
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,20 +1,21 @@
 <Project>
-
-    <ItemGroup>
-        <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
-        <PackageVersion Include="Benjamin.Pizza.DocTest" Version="1.1.0" />
-        <PackageVersion Include="FParsec" Version="1.1.1" />
-        <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-        <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.3.2" />
-        <PackageVersion Include="Microsoft.Testing.Extensions.TrxReport" Version="2.0.2" />
-        <PackageVersion Include="Sprache" Version="2.3.1" />
-        <PackageVersion Include="Superpower" Version="3.1.0" />
-        <PackageVersion Include="xunit.v3.mtp-v2" Version="3.2.2" />
-    </ItemGroup>
-
-    <ItemGroup>
-        <GlobalPackageReference Include="Benjamin.Pizza.BuildScripts" Version="2.4.0" />
-        <GlobalPackageReference Include="StyleCop.Analyzers" Version="1.1.118" />
-    </ItemGroup>
-
+  <ItemGroup>
+    <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
+    <PackageVersion Include="Benjamin.Pizza.DocTest" Version="1.1.0" />
+    <PackageVersion Include="FParsec" Version="1.1.1" />
+    <PackageVersion Include="Meziantou.Polyfill" Version="1.0.110" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.3.2" />
+    <PackageVersion Include="Microsoft.Testing.Extensions.TrxReport" Version="2.0.2" />
+    <PackageVersion Include="Sprache" Version="2.3.1" />
+    <PackageVersion Include="Superpower" Version="3.1.0" />
+    <PackageVersion Include="System.Collections.Immutable" Version="10.0.5" />
+    <PackageVersion Include="System.Memory" Version="4.6.3" />
+    <PackageVersion Include="System.Runtime.CompilerServices.Unsafe" Version="6.1.2" />
+    <PackageVersion Include="xunit.v3.mtp-v2" Version="3.2.2" />
+  </ItemGroup>
+  <ItemGroup>
+    <GlobalPackageReference Include="Benjamin.Pizza.BuildScripts" Version="2.4.0" />
+    <GlobalPackageReference Include="StyleCop.Analyzers" Version="1.1.118" />
+  </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,11 +1,9 @@
-@ -1,20 +1,21 @@
 <Project>
 
     <ItemGroup>
         <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
         <PackageVersion Include="Benjamin.Pizza.DocTest" Version="1.1.0" />
         <PackageVersion Include="FParsec" Version="1.1.1" />
-		<PackageVersion Include="Meziantou.Polyfill" Version="1.0.110" />
         <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
         <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.3.2" />
         <PackageVersion Include="Microsoft.Testing.Extensions.TrxReport" Version="2.0.2" />
@@ -19,6 +17,7 @@
 
     <ItemGroup>
         <GlobalPackageReference Include="Benjamin.Pizza.BuildScripts" Version="2.4.0" />
+		<GlobalPackageReference Include="Meziantou.Polyfill" Version="1.0.110" />
         <GlobalPackageReference Include="StyleCop.Analyzers" Version="1.1.118" />
     </ItemGroup>
 

--- a/Pidgin/Expected.cs
+++ b/Pidgin/Expected.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Collections.Immutable;
+#if !NETSTANDARD2_0
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+#endif
 using System.Text;
 
 namespace Pidgin;
@@ -196,9 +198,22 @@ public readonly struct Expected<TToken> : IEquatable<Expected<TToken>>, ICompara
     public static bool operator <=(Expected<TToken> left, Expected<TToken> right)
         => left.CompareTo(right) <= 0;
 
+#if NETSTANDARD2_0
+    private static ReadOnlySpan<char> UnsafeCastToChar(ReadOnlySpan<TToken> span)
+    {
+        var chars = new char[span.Length];
+        for (var i = 0; i < span.Length; i++)
+        {
+            chars[i] = (char)(object)span[i]!;
+        }
+
+        return chars;
+    }
+#else
     private static ReadOnlySpan<char> UnsafeCastToChar(ReadOnlySpan<TToken> span)
         => MemoryMarshal.CreateReadOnlySpan(
             ref Unsafe.As<TToken, char>(ref MemoryMarshal.GetReference(span)),
             span.Length
         );
+#endif
 }

--- a/Pidgin/Expected.cs
+++ b/Pidgin/Expected.cs
@@ -1,10 +1,10 @@
 using System;
 using System.Collections.Immutable;
-#if !NETSTANDARD2_0
+using System.Text;
+#if NETCOREAPP2_1_OR_GREATER
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 #endif
-using System.Text;
 
 namespace Pidgin;
 
@@ -198,22 +198,22 @@ public readonly struct Expected<TToken> : IEquatable<Expected<TToken>>, ICompara
     public static bool operator <=(Expected<TToken> left, Expected<TToken> right)
         => left.CompareTo(right) <= 0;
 
-#if NETSTANDARD2_0
-    private static ReadOnlySpan<char> UnsafeCastToChar(ReadOnlySpan<TToken> span)
-    {
-        var chars = new char[span.Length];
-        for (var i = 0; i < span.Length; i++)
-        {
-            chars[i] = (char)(object)span[i]!;
-        }
-
-        return chars;
-    }
-#else
+#if NETCOREAPP2_1_OR_GREATER
     private static ReadOnlySpan<char> UnsafeCastToChar(ReadOnlySpan<TToken> span)
         => MemoryMarshal.CreateReadOnlySpan(
             ref Unsafe.As<TToken, char>(ref MemoryMarshal.GetReference(span)),
             span.Length
         );
+#else
+    private static ReadOnlySpan<char> UnsafeCastToChar(ReadOnlySpan<TToken> span)
+    {
+        var chars = new StringBuilder(span.Length);
+        for (var i = 0; i < span.Length; i++)
+        {
+            chars.Append(span[i]);
+        }
+
+        return chars.ToString();
+    }
 #endif
 }

--- a/Pidgin/ITokenStream.cs
+++ b/Pidgin/ITokenStream.cs
@@ -38,12 +38,12 @@ public interface ITokenStream<TToken>
         "CA1716:Rename member so that it no longer conflicts with a reserved language keyword",
         Justification = "Would be a breaking change"
     )]
-#if NETSTANDARD2_0
-    public void Return(ReadOnlySpan<TToken> leftovers);
-#else
+#if NETCOREAPP3_0_OR_GREATER
     public void Return(ReadOnlySpan<TToken> leftovers)
     {
     }
+#else
+    public void Return(ReadOnlySpan<TToken> leftovers);
 #endif
 
     /// <summary>
@@ -57,9 +57,9 @@ public interface ITokenStream<TToken>
     /// The default is 1024.
     /// </summary>
     /// <returns>The default number of tokens to request when calling <see cref="Read"/>.</returns>
-#if NETSTANDARD2_0
-    public int ChunkSizeHint { get; }
-#else
+#if NETCOREAPP3_0_OR_GREATER
     public int ChunkSizeHint => 1024;
+#else
+    public int ChunkSizeHint { get; }
 #endif
 }

--- a/Pidgin/ITokenStream.cs
+++ b/Pidgin/ITokenStream.cs
@@ -38,9 +38,13 @@ public interface ITokenStream<TToken>
         "CA1716:Rename member so that it no longer conflicts with a reserved language keyword",
         Justification = "Would be a breaking change"
     )]
+#if NETSTANDARD2_0
+    public void Return(ReadOnlySpan<TToken> leftovers);
+#else
     public void Return(ReadOnlySpan<TToken> leftovers)
     {
     }
+#endif
 
     /// <summary>
     /// A hint to the parser indicating a default number of tokens to request when calling <see cref="Read"/>.
@@ -53,5 +57,9 @@ public interface ITokenStream<TToken>
     /// The default is 1024.
     /// </summary>
     /// <returns>The default number of tokens to request when calling <see cref="Read"/>.</returns>
+#if NETSTANDARD2_0
+    public int ChunkSizeHint { get; }
+#else
     public int ChunkSizeHint => 1024;
+#endif
 }

--- a/Pidgin/Incremental/ConditionalWeakReference.cs
+++ b/Pidgin/Incremental/ConditionalWeakReference.cs
@@ -60,12 +60,12 @@ internal class ConditionalWeakReference
     }
 #else
     private readonly WeakReference _target;
-    private readonly WeakReference _dependent;
+    private readonly object? _dependent;
 
     public ConditionalWeakReference(object? target, object? dependent)
     {
         _target = new WeakReference(target);
-        _dependent = new WeakReference(dependent);
+        _dependent = dependent;
     }
 
     public object? Target
@@ -82,7 +82,7 @@ internal class ConditionalWeakReference
     {
         get
         {
-            var result = _dependent.Target;
+            var result = _dependent;
             GC.KeepAlive(this);
             return result;
         }
@@ -92,7 +92,7 @@ internal class ConditionalWeakReference
     {
         get
         {
-            var result = (_target.Target, _dependent.Target);
+            var result = (_target.Target, _dependent);
             GC.KeepAlive(this);
             return result;
         }

--- a/Pidgin/Incremental/ConditionalWeakReference.cs
+++ b/Pidgin/Incremental/ConditionalWeakReference.cs
@@ -1,5 +1,5 @@
 using System;
-#if NET8_0_OR_GREATER
+#if NET6_0_OR_GREATER
 using System.Runtime;
 #endif
 
@@ -11,7 +11,7 @@ namespace Pidgin.Incremental;
 /// </summary>
 internal class ConditionalWeakReference
 {
-#if NET8_0_OR_GREATER
+#if NET6_0_OR_GREATER
     // DependentHandle is a mutable struct - don't make this readonly
     private DependentHandle _handle;
 

--- a/Pidgin/Incremental/ConditionalWeakReference.cs
+++ b/Pidgin/Incremental/ConditionalWeakReference.cs
@@ -1,5 +1,7 @@
 using System;
+#if NET8_0_OR_GREATER
 using System.Runtime;
+#endif
 
 namespace Pidgin.Incremental;
 
@@ -9,6 +11,7 @@ namespace Pidgin.Incremental;
 /// </summary>
 internal class ConditionalWeakReference
 {
+#if NET8_0_OR_GREATER
     // DependentHandle is a mutable struct - don't make this readonly
     private DependentHandle _handle;
 
@@ -55,4 +58,44 @@ internal class ConditionalWeakReference
         // DependentHandle.Dispose is idempotent.
         _handle.Dispose();
     }
+#else
+    private readonly WeakReference _target;
+    private readonly WeakReference _dependent;
+
+    public ConditionalWeakReference(object? target, object? dependent)
+    {
+        _target = new WeakReference(target);
+        _dependent = new WeakReference(dependent);
+    }
+
+    public object? Target
+    {
+        get
+        {
+            var result = _target.Target;
+            GC.KeepAlive(this);
+            return result;
+        }
+    }
+
+    public object? Dependent
+    {
+        get
+        {
+            var result = _dependent.Target;
+            GC.KeepAlive(this);
+            return result;
+        }
+    }
+
+    public (object? Target, object? Dependent) TargetAndDependent
+    {
+        get
+        {
+            var result = (_target.Target, _dependent.Target);
+            GC.KeepAlive(this);
+            return result;
+        }
+    }
+#endif
 }

--- a/Pidgin/ParseState.ComputeSourcePos.cs
+++ b/Pidgin/ParseState.ComputeSourcePos.cs
@@ -65,11 +65,13 @@ public partial struct ParseState<TToken>
             _span.Length
         ).Slice(start, end);
 #else
-        var input = new StringBuilder(end);
+        var inputString = new StringBuilder(end);
         for (var j = start; j < start + end; j++)
         {
-            input.Append(_span[j]);
+            inputString.Append(_span[j]);
         }
+
+        var input = inputString.ToString();
 #endif
         var lines = 0;
         var cols = 0;

--- a/Pidgin/ParseState.ComputeSourcePos.cs
+++ b/Pidgin/ParseState.ComputeSourcePos.cs
@@ -1,7 +1,10 @@
 using System;
-#if !NETSTANDARD2_0
+
+#if NETCOREAPP2_1_OR_GREATER
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+#else
+using System.Text;
 #endif
 
 using Pidgin.Configuration;
@@ -55,22 +58,19 @@ public partial struct ParseState<TToken>
         var start = (int)(_lastSourcePosDeltaLocation - _bufferStartLocation);
         var end = (int)(location - _lastSourcePosDeltaLocation);
 
+#if NETCOREAPP2_1_OR_GREATER
         // coerce _span to Span<char>
-#if NETSTANDARD2_0
-        var inputBuffer = new char[_span.Length];
-        for (var s = 0; s < _span.Length; s++)
-        {
-            inputBuffer[s] = (char)(object)_span[s]!;
-        }
-
-        var input = inputBuffer.AsSpan().Slice(start, end);
-#else
         var input = MemoryMarshal.CreateSpan(
             ref Unsafe.As<TToken, char>(ref MemoryMarshal.GetReference(_span)),
             _span.Length
         ).Slice(start, end);
+#else
+        var input = new StringBuilder(end);
+        for (var j = start; j < start + end; j++)
+        {
+            input.Append(_span[j]);
+        }
 #endif
-
         var lines = 0;
         var cols = 0;
 

--- a/Pidgin/ParseState.ComputeSourcePos.cs
+++ b/Pidgin/ParseState.ComputeSourcePos.cs
@@ -1,6 +1,8 @@
 using System;
+#if !NETSTANDARD2_0
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+#endif
 
 using Pidgin.Configuration;
 
@@ -54,10 +56,20 @@ public partial struct ParseState<TToken>
         var end = (int)(location - _lastSourcePosDeltaLocation);
 
         // coerce _span to Span<char>
+#if NETSTANDARD2_0
+        var inputBuffer = new char[_span.Length];
+        for (var s = 0; s < _span.Length; s++)
+        {
+            inputBuffer[s] = (char)(object)_span[s]!;
+        }
+
+        var input = inputBuffer.AsSpan().Slice(start, end);
+#else
         var input = MemoryMarshal.CreateSpan(
             ref Unsafe.As<TToken, char>(ref MemoryMarshal.GetReference(_span)),
             _span.Length
         ).Slice(start, end);
+#endif
 
         var lines = 0;
         var cols = 0;

--- a/Pidgin/ParseState.cs
+++ b/Pidgin/ParseState.cs
@@ -26,7 +26,11 @@ namespace Pidgin;
 [EditorBrowsable(EditorBrowsableState.Advanced)]
 public ref partial struct ParseState<TToken>
 {
+#if NETSTANDARD2_0
+    private static readonly bool _needsClear = true;
+#else
     private static readonly bool _needsClear = RuntimeHelpers.IsReferenceOrContainsReferences<TToken>();
+#endif
 
     /// <summary>Gets the parser configuration.</summary>
     public IConfiguration<TToken> Configuration { get; }

--- a/Pidgin/ParseState.cs
+++ b/Pidgin/ParseState.cs
@@ -26,10 +26,10 @@ namespace Pidgin;
 [EditorBrowsable(EditorBrowsableState.Advanced)]
 public ref partial struct ParseState<TToken>
 {
-#if NETSTANDARD2_0
-    private static readonly bool _needsClear = true;
-#else
+#if NETCOREAPP2_0_OR_GREATER
     private static readonly bool _needsClear = RuntimeHelpers.IsReferenceOrContainsReferences<TToken>();
+#else
+    private static readonly bool _needsClear = true;
 #endif
 
     /// <summary>Gets the parser configuration.</summary>

--- a/Pidgin/Pidgin.csproj
+++ b/Pidgin/Pidgin.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFrameworks>netstandard2.0;net7.0</TargetFrameworks>
         <CheckEolTargetFramework>false</CheckEolTargetFramework>
         <LangVersion>latest</LangVersion>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -14,7 +14,17 @@
     </ItemGroup>
 
     <ItemGroup>
-        <None Include="../README.md" Pack="true" PackagePath="/"/>
+        <None Include="../README.md" Pack="true" PackagePath="/" />
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+        <PackageReference Include="System.Memory" />
+        <PackageReference Include="System.Collections.Immutable" />
+        <PackageReference Include="Meziantou.Polyfill">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="System.Runtime.CompilerServices.Unsafe" />
     </ItemGroup>
 
 </Project>

--- a/Pidgin/Pidgin.csproj
+++ b/Pidgin/Pidgin.csproj
@@ -20,10 +20,6 @@
     <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
         <PackageReference Include="System.Memory" />
         <PackageReference Include="System.Collections.Immutable" />
-        <PackageReference Include="Meziantou.Polyfill">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
         <PackageReference Include="System.Runtime.CompilerServices.Unsafe" />
     </ItemGroup>
 

--- a/Pidgin/PooledList.cs
+++ b/Pidgin/PooledList.cs
@@ -18,7 +18,11 @@ namespace Pidgin;
 [SuppressMessage("performance", "CA1815:Struct should override Equals", Justification = "This type is not meant to be equatable")]
 public struct PooledList<T> : IDisposable, IList<T>
 {
+#if NETSTANDARD2_0
+    private static readonly bool _needsClear = true;
+#else
     private static readonly bool _needsClear = RuntimeHelpers.IsReferenceOrContainsReferences<T>();
+#endif
     internal const int InitialCapacity = 16;  // for testing
 
     private ArrayPool<T> _arrayPool;

--- a/Pidgin/PooledList.cs
+++ b/Pidgin/PooledList.cs
@@ -18,10 +18,10 @@ namespace Pidgin;
 [SuppressMessage("performance", "CA1815:Struct should override Equals", Justification = "This type is not meant to be equatable")]
 public struct PooledList<T> : IDisposable, IList<T>
 {
-#if NETSTANDARD2_0
-    private static readonly bool _needsClear = true;
-#else
+#if NETCOREAPP2_0_OR_GREATER
     private static readonly bool _needsClear = RuntimeHelpers.IsReferenceOrContainsReferences<T>();
+#else
+    private static readonly bool _needsClear = true;
 #endif
     internal const int InitialCapacity = 16;  // for testing
 

--- a/Pidgin/TokenStreams/EnumeratorTokenStream.cs
+++ b/Pidgin/TokenStreams/EnumeratorTokenStream.cs
@@ -53,7 +53,7 @@ public class EnumeratorTokenStream<TToken> : ITokenStream<TToken>
         return buffer.Length;
     }
 
-#if NETSTANDARD2_0
+#if !NETCOREAPP3_0_OR_GREATER
     /// <summary>
     /// Push some un-consumed tokens back into the stream.
     /// <see cref="Parser{TToken, T}"/>s call this method when they are finished parsing.

--- a/Pidgin/TokenStreams/EnumeratorTokenStream.cs
+++ b/Pidgin/TokenStreams/EnumeratorTokenStream.cs
@@ -52,4 +52,20 @@ public class EnumeratorTokenStream<TToken> : ITokenStream<TToken>
 
         return buffer.Length;
     }
+
+#if NETSTANDARD2_0
+    /// <summary>
+    /// Push some un-consumed tokens back into the stream.
+    /// <see cref="Parser{TToken, T}"/>s call this method when they are finished parsing.
+    ///
+    /// <see cref="ITokenStream{TToken}"/> implementations may override this
+    /// method if they want to implement resumable parsing.
+    /// (See <see cref="ResumableTokenStream{TToken}"/>.)
+    /// The default implementation does nothing and discards the <paramref name="leftovers"/>.
+    /// </summary>
+    /// <param name="leftovers">The leftovers to push back into the stream.</param>
+    public void Return(ReadOnlySpan<TToken> leftovers)
+    {
+    }
+#endif
 }

--- a/Pidgin/TokenStreams/ListTokenStream.cs
+++ b/Pidgin/TokenStreams/ListTokenStream.cs
@@ -49,4 +49,20 @@ public sealed class ListTokenStream<TToken> : ITokenStream<TToken>
 
         return actualLength;
     }
+
+#if NETSTANDARD2_0
+    /// <summary>
+    /// Push some un-consumed tokens back into the stream.
+    /// <see cref="Parser{TToken, T}"/>s call this method when they are finished parsing.
+    ///
+    /// <see cref="ITokenStream{TToken}"/> implementations may override this
+    /// method if they want to implement resumable parsing.
+    /// (See <see cref="ResumableTokenStream{TToken}"/>.)
+    /// The default implementation does nothing and discards the <paramref name="leftovers"/>.
+    /// </summary>
+    /// <param name="leftovers">The leftovers to push back into the stream.</param>
+    public void Return(ReadOnlySpan<TToken> leftovers)
+    {
+    }
+#endif
 }

--- a/Pidgin/TokenStreams/ListTokenStream.cs
+++ b/Pidgin/TokenStreams/ListTokenStream.cs
@@ -50,7 +50,7 @@ public sealed class ListTokenStream<TToken> : ITokenStream<TToken>
         return actualLength;
     }
 
-#if NETSTANDARD2_0
+#if !NETCOREAPP3_0_OR_GREATER
     /// <summary>
     /// Push some un-consumed tokens back into the stream.
     /// <see cref="Parser{TToken, T}"/>s call this method when they are finished parsing.

--- a/Pidgin/TokenStreams/ReadOnlyListTokenStream.cs
+++ b/Pidgin/TokenStreams/ReadOnlyListTokenStream.cs
@@ -50,7 +50,7 @@ public sealed class ReadOnlyListTokenStream<TToken> : ITokenStream<TToken>
         return actualLength;
     }
 
-#if NETSTANDARD2_0
+#if !NETCOREAPP3_0_OR_GREATER
     /// <summary>
     /// Push some un-consumed tokens back into the stream.
     /// <see cref="Parser{TToken, T}"/>s call this method when they are finished parsing.

--- a/Pidgin/TokenStreams/ReadOnlyListTokenStream.cs
+++ b/Pidgin/TokenStreams/ReadOnlyListTokenStream.cs
@@ -49,4 +49,21 @@ public sealed class ReadOnlyListTokenStream<TToken> : ITokenStream<TToken>
 
         return actualLength;
     }
+
+#if NETSTANDARD2_0
+    /// <summary>
+    /// Push some un-consumed tokens back into the stream.
+    /// <see cref="Parser{TToken, T}"/>s call this method when they are finished parsing.
+    ///
+    /// <see cref="ITokenStream{TToken}"/> implementations may override this
+    /// method if they want to implement resumable parsing.
+    /// (See <see cref="ResumableTokenStream{TToken}"/>.)
+    /// The default implementation does nothing and discards the <paramref name="leftovers"/>.
+    /// </summary>
+    /// <param name="leftovers">The leftovers to push back into the stream.</param>
+    public void Return(ReadOnlySpan<TToken> leftovers)
+    {
+    }
+#endif
+
 }

--- a/Pidgin/TokenStreams/ReaderTokenStream.cs
+++ b/Pidgin/TokenStreams/ReaderTokenStream.cs
@@ -36,5 +36,31 @@ public class ReaderTokenStream : ITokenStream<char>
     /// </summary>
     /// <param name="buffer">The buffer to read tokens into.</param>
     /// <returns>The actual number of tokens read.</returns>
-    public int Read(Span<char> buffer) => _input.Read(buffer);
+    public int Read(Span<char> buffer)
+    {
+#if NETSTANDARD2_0
+        var temp = new char[buffer.Length];
+        var read = _input.Read(temp, 0, buffer.Length);
+        temp.CopyTo(buffer);
+        return read;
+#else
+        return _input.Read(buffer);
+#endif
+    }
+
+#if NETSTANDARD2_0
+    /// <summary>
+    /// Push some un-consumed tokens back into the stream.
+    /// <see cref="Parser{TToken, T}"/>s call this method when they are finished parsing.
+    ///
+    /// <see cref="ITokenStream{TToken}"/> implementations may override this
+    /// method if they want to implement resumable parsing.
+    /// (See <see cref="ResumableTokenStream{TToken}"/>.)
+    /// The default implementation does nothing and discards the <paramref name="leftovers"/>.
+    /// </summary>
+    /// <param name="leftovers">The leftovers to push back into the stream.</param>
+    public void Return(ReadOnlySpan<char> leftovers)
+    {
+    }
+#endif
 }

--- a/Pidgin/TokenStreams/ReaderTokenStream.cs
+++ b/Pidgin/TokenStreams/ReaderTokenStream.cs
@@ -62,7 +62,7 @@ public class ReaderTokenStream : ITokenStream<char>
 #endif
     }
 
-#if NETSTANDARD2_0
+#if !NETCOREAPP3_0_OR_GREATER
     /// <summary>
     /// Push some un-consumed tokens back into the stream.
     /// <see cref="Parser{TToken, T}"/>s call this method when they are finished parsing.

--- a/Pidgin/TokenStreams/ReaderTokenStream.cs
+++ b/Pidgin/TokenStreams/ReaderTokenStream.cs
@@ -1,6 +1,9 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
+#if NETSTANDARD2_0
+using System.Buffers;
+#endif
 
 namespace Pidgin.TokenStreams;
 
@@ -39,10 +42,21 @@ public class ReaderTokenStream : ITokenStream<char>
     public int Read(Span<char> buffer)
     {
 #if NETSTANDARD2_0
-        var temp = new char[buffer.Length];
-        var read = _input.Read(temp, 0, buffer.Length);
-        temp.CopyTo(buffer);
-        return read;
+        var temp = ArrayPool<char>.Shared.Rent(buffer.Length);
+        try
+        {
+            var read = _input.Read(temp, 0, buffer.Length);
+            if (read > 0)
+            {
+                temp.AsSpan(0, read).CopyTo(buffer);
+            }
+
+            return read;
+        }
+        finally
+        {
+            ArrayPool<char>.Shared.Return(temp);
+        }
 #else
         return _input.Read(buffer);
 #endif

--- a/Pidgin/TokenStreams/ReaderTokenStream.cs
+++ b/Pidgin/TokenStreams/ReaderTokenStream.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
-#if NETSTANDARD2_0
+#if !NETCOREAPP2_1_OR_GREATER
 using System.Buffers;
 #endif
 
@@ -41,7 +41,9 @@ public class ReaderTokenStream : ITokenStream<char>
     /// <returns>The actual number of tokens read.</returns>
     public int Read(Span<char> buffer)
     {
-#if NETSTANDARD2_0
+#if NETCOREAPP2_1_OR_GREATER
+        return _input.Read(buffer);
+#else
         var temp = ArrayPool<char>.Shared.Rent(buffer.Length);
         try
         {
@@ -57,8 +59,6 @@ public class ReaderTokenStream : ITokenStream<char>
         {
             ArrayPool<char>.Shared.Return(temp);
         }
-#else
-        return _input.Read(buffer);
 #endif
     }
 

--- a/Pidgin/TokenStreams/ResumableTokenStream.cs
+++ b/Pidgin/TokenStreams/ResumableTokenStream.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Buffers;
 using System.Diagnostics.CodeAnalysis;
+#if !NETSTANDARD2_0
 using System.Runtime.CompilerServices;
+#endif
 
 namespace Pidgin.TokenStreams;
 
@@ -17,7 +19,11 @@ namespace Pidgin.TokenStreams;
 )]
 public class ResumableTokenStream<TToken> : ITokenStream<TToken>, IDisposable
 {
+#if NETSTANDARD2_0
+    private static readonly bool _needsClear = true;
+#else
     private static readonly bool _needsClear = RuntimeHelpers.IsReferenceOrContainsReferences<TToken>();
+#endif
     private readonly ArrayPool<TToken> _pool;
     private readonly ITokenStream<TToken> _next;
     private TToken[]? _buffer = null;
@@ -115,4 +121,11 @@ public class ResumableTokenStream<TToken> : ITokenStream<TToken>, IDisposable
             _bufferStart = 0;
         }
     }
+
+#if NETSTANDARD2_0
+    /// <summary>
+    /// Chunk Size Hint.
+    /// </summary>
+    public int ChunkSizeHint => 1024;
+#endif
 }

--- a/Pidgin/TokenStreams/ResumableTokenStream.cs
+++ b/Pidgin/TokenStreams/ResumableTokenStream.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Buffers;
 using System.Diagnostics.CodeAnalysis;
-#if !NETSTANDARD2_0
+#if NETCOREAPP2_0_OR_GREATER
 using System.Runtime.CompilerServices;
 #endif
 
@@ -122,7 +122,7 @@ public class ResumableTokenStream<TToken> : ITokenStream<TToken>, IDisposable
         }
     }
 
-#if NETSTANDARD2_0
+#if !NETCOREAPP3_0_OR_GREATER
     /// <summary>
     /// Chunk Size Hint.
     /// </summary>

--- a/Pidgin/TokenStreams/ResumableTokenStream.cs
+++ b/Pidgin/TokenStreams/ResumableTokenStream.cs
@@ -19,10 +19,10 @@ namespace Pidgin.TokenStreams;
 )]
 public class ResumableTokenStream<TToken> : ITokenStream<TToken>, IDisposable
 {
-#if NETSTANDARD2_0
-    private static readonly bool _needsClear = true;
-#else
+#if NETCOREAPP2_0_OR_GREATER
     private static readonly bool _needsClear = RuntimeHelpers.IsReferenceOrContainsReferences<TToken>();
+#else
+    private static readonly bool _needsClear = true;
 #endif
     private readonly ArrayPool<TToken> _pool;
     private readonly ITokenStream<TToken> _next;

--- a/Pidgin/TokenStreams/StreamTokenStream.cs
+++ b/Pidgin/TokenStreams/StreamTokenStream.cs
@@ -38,7 +38,7 @@ public class StreamTokenStream : ITokenStream<byte>
     /// <returns>The actual number of tokens read.</returns>
     public int Read(Span<byte> buffer) => _input.Read(buffer);
 
-#if NETSTANDARD2_0
+#if !NETCOREAPP3_0_OR_GREATER
     /// <summary>
     /// Push some un-consumed tokens back into the stream.
     /// <see cref="Parser{TToken, T}"/>s call this method when they are finished parsing.

--- a/Pidgin/TokenStreams/StreamTokenStream.cs
+++ b/Pidgin/TokenStreams/StreamTokenStream.cs
@@ -37,4 +37,20 @@ public class StreamTokenStream : ITokenStream<byte>
     /// <param name="buffer">The buffer to read tokens into.</param>
     /// <returns>The actual number of tokens read.</returns>
     public int Read(Span<byte> buffer) => _input.Read(buffer);
+
+#if NETSTANDARD2_0
+    /// <summary>
+    /// Push some un-consumed tokens back into the stream.
+    /// <see cref="Parser{TToken, T}"/>s call this method when they are finished parsing.
+    ///
+    /// <see cref="ITokenStream{TToken}"/> implementations may override this
+    /// method if they want to implement resumable parsing.
+    /// (See <see cref="ResumableTokenStream{TToken}"/>.)
+    /// The default implementation does nothing and discards the <paramref name="leftovers"/>.
+    /// </summary>
+    /// <param name="leftovers">The leftovers to push back into the stream.</param>
+    public void Return(ReadOnlySpan<byte> leftovers)
+    {
+    }
+#endif
 }


### PR DESCRIPTION
This PR attempts to restore netstandard2.0 support in order to allow this library to be used in source generators (again). It adds a second target for netstandard2.0 and implements the minimal changes required to compile.

It should not affect the current NET7 target, all the changes should be limited to netstandard2.0. There will be a performance cost on netstandard2.0 when compared to NET Core.

Addresses https://github.com/benjamin-hodgson/Pidgin/issues/175 at the cost of shipping 2 incompatible libraries inside the same package. 